### PR TITLE
fix: 优化快速拉线

### DIFF
--- a/src/components/ActionConnector.vue
+++ b/src/components/ActionConnector.vue
@@ -200,6 +200,7 @@ const onDragTarget = (evt) => {
     :is-selected="isSelected"
     :is-dimmed="isDimmed"
     :is-highlighted="isRelatedToHover"
+    :is-selectable="!connectionHandler.isDragging.value"
     @click="onSelectClick"
     @contextmenu="onContextMenu"
     @drag-start-target="onDragTarget"

--- a/src/components/ActionItem.vue
+++ b/src/components/ActionItem.vue
@@ -396,8 +396,8 @@ function handleEffectDrop(effectId) {
       @drag-start="handleActionDragStart" @clear-snap="connectionHandler.clearSnap"
       :isDragging="connectionHandler.isDragging.value"
       :disabled="connectionSourceActionId === props.action.instanceId"
-      v-if="!isGhostMode && !store.isDraggingLink"
-      :show="isSelected || store.hoveredActionId === action.instanceId || (connectionHandler.isDragging.value && connectionSourceActionId !== action.instanceId)" :color="themeColor" />
+      v-if="!isGhostMode && store.hoveredActionId === action.instanceId || connectionHandler.isDragging.value || (connectionHandler.isDragging.value && connectionSourceActionId !== action.instanceId)"
+      :color="themeColor" />
 
     <div v-if="!isGhostMode" class="anomalies-overlay">
       <div v-for="(item, index) in renderableAnomalies" :key="`${item.rowIndex}-${item.colIndex}`"

--- a/src/components/ActionLinkPorts.vue
+++ b/src/components/ActionLinkPorts.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 
 const props = defineProps({
-    show: { type: Boolean, default: false },
+    show: { type: Boolean, default: true },
     color: { type: String, default: '#fff' },
     isDragging: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false }
@@ -121,7 +121,7 @@ const ports = [
             :style="{ '--background-color': color }"
             :class="['link-port', p.class, `port-${p.side}`, { 'active': activePort === p.side }]"
             @mousedown.stop.prevent="onPortMouseDown($event, p)" @mouseenter.stop="onPortMouseEnter($event, p)"
-            @mouseleave.stop="onPortMouseLeave" @mouseup.stop="onPortMouseUp" title="Drag to connect">
+            @mouseleave.stop="onPortMouseLeave" @mouseup.stop="onPortMouseUp" title="拖拽连线">
         </div>
     </div>
 </template>

--- a/src/components/ConnectionPath.vue
+++ b/src/components/ConnectionPath.vue
@@ -24,6 +24,7 @@ const props = defineProps({
   isSelected: { type: Boolean, default: false },
   isDimmed: { type: Boolean, default: false },
   isHighlighted: { type: Boolean, default: false },
+  isSelectable: { type: Boolean, default: true },
   isPreview: { type: Boolean, default: false }
 })
 
@@ -62,7 +63,8 @@ const pathData = computed(() => {
     'is-selected': isSelected,
     'is-dimmed': isDimmed,
     'is-highlighted': isHighlighted,
-    'is-preview': isPreview
+    'is-preview': isPreview,
+    'is-selectable': isSelectable
   }" @click.stop="emit('click', $event)" @contextmenu.prevent.stop="emit('contextmenu', $event)">
     <defs>
       <linearGradient :id="gradientId" gradientUnits="userSpaceOnUse" :x1="startPoint.x" :y1="startPoint.y"
@@ -73,8 +75,8 @@ const pathData = computed(() => {
     </defs>
 
     <path :d="pathData" fill="none" :stroke="colors.end" stroke-width="12" class="hover-zone"
-      :class="{ 'is-preview': isPreview }">
-      <title>Left click to select, Del to delete</title>
+      :class="{ 'is-preview': isPreview, 'is-selectable': isSelectable }">
+      <title>左键选中后按 Delete 删除</title>
     </path>
 
     <path :d="pathData" fill="none" :stroke="isSelected ? '#ffffff' : `url(#${gradientId})`" stroke-width="2"
@@ -96,9 +98,9 @@ const pathData = computed(() => {
 
 <style scoped>
 .connector-group {
-  cursor: pointer;
   transition: opacity 0.2s, filter 0.2s;
-
+  cursor: pointer;
+  
   &.is-dimmed {
     opacity: 0.1;
     filter: grayscale(0.8);
@@ -111,7 +113,7 @@ const pathData = computed(() => {
   }
 }
 
-.connector-group.is-highlighted .main-path {
+.connector-group.is-selectable.is-highlighted .main-path {
   stroke-width: 3;
   filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.4));
 }
@@ -123,9 +125,12 @@ const pathData = computed(() => {
 }
 
 .hover-zone {
-  pointer-events: stroke;
   transition: stroke-opacity 0.2s;
   stroke-opacity: 0;
+
+  &.is-selectable {
+    pointer-events: stroke;
+  }
 
   &.is-preview {
     pointer-events: none;


### PR DESCRIPTION
拉线时显示起始动作的端口
拉线时不会触发已有连线的hover状态
修复两个文本错误