### PR TITLE
fix: 替换截图库

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "endaxis-vue",
       "version": "0.0.0",
       "dependencies": {
+        "@zumer/snapdom": "^2.0.1",
         "element-plus": "^2.11.8",
+        "html-to-image": "^1.11.13",
         "html2canvas": "^1.4.1",
         "lz-string": "^1.5.0",
         "pinia": "^3.0.4",
@@ -1738,6 +1740,12 @@
         }
       }
     },
+    "node_modules/@zumer/snapdom": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@zumer/snapdom/-/snapdom-2.0.1.tgz",
+      "integrity": "sha512-78/qbYl2FTv4H6qaXcNfAujfIOSzdvs83NW63VbyC9QA3sqNPfPvhn4xYMO6Gy11hXwJUEhd0z65yKiNzDwy9w==",
+      "license": "MIT"
+    },
     "node_modules/ansis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
@@ -2117,6 +2125,12 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/html2canvas": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@zumer/snapdom": "^2.0.1",
     "element-plus": "^2.11.8",
     "html2canvas": "^1.4.1",
     "lz-string": "^1.5.0",

--- a/src/components/TimelineGrid.vue
+++ b/src/components/TimelineGrid.vue
@@ -1482,6 +1482,10 @@ onUnmounted(() => {
   transition: transform 0.1s;
 }
 
+body.capture-mode .davinci-range {
+  opacity: 0;
+}
+
 .davinci-range::-webkit-slider-thumb:hover {
   transform: scale(1.3);
   background: #fff;


### PR DESCRIPTION
把`html2canvas`换成`snapdom`

截图（特别是图比较长）的时候，图片左边会出现右边内容的“阴影”。下图中体现为黑框和多余的分界线
<img width="14925" height="1861" alt="Endaxis_Timeline_2025-12-27 (88)" src="https://github.com/user-attachments/assets/8cad8cca-38c9-4405-8bdf-e7bb4ba072aa" />

具体原因不明但是应该是`html2canvas`的bug。这个库也好久没更新了，换成`snapdom`可以解决这个问题。

由于截图原理不同需要额外对svg和input[range]稍微做一些处理，但是导出的图片我看上去和原来没什么区别。
上图的`snapdom`版本
<img width="24645" height="1861" alt="Endaxis_Timeline_2025-12-27 (89)" src="https://github.com/user-attachments/assets/1a2f741e-6104-4fd8-a5ee-bdca620db672" />
