### PR TITLE
fix: 去除大部分时间轴区域的getBoundingClientRect()

### DIFF
--- a/src/components/ConnectionPreview.vue
+++ b/src/components/ConnectionPreview.vue
@@ -5,7 +5,7 @@ import ConnectionPath from './ConnectionPath.vue'
 import { useDragConnection } from '@/composables/useDragConnection.js'
 import { PORT_DIRECTIONS } from '@/utils/layoutUtils.js'
 
-const props = defineProps({ containerRef: { type: Object, required: false } })
+const props = defineProps({})
 const store = useTimelineStore()
 const connectionHandler = useDragConnection()
 
@@ -16,25 +16,17 @@ const startPoint = computed(() => {
     return null
   }
 
-  const container = props.containerRef.getBoundingClientRect()
-
-  const scrollX = props.containerRef.scrollLeft
-  const scrollY = props.containerRef.scrollTop
+  const scrollX = store.timelineScrollLeft
+  const scrollY = store.timelineScrollTop
 
   return {
-    x: (state.startPoint.x - container.left) + scrollX,
-    y: (state.startPoint.y - container.top) + scrollY,
+    x: (state.startPoint.x - store.timelineRect.left) + scrollX,
+    y: (state.startPoint.y - store.timelineRect.top) + scrollY,
     dir: PORT_DIRECTIONS[state.sourcePort]
   }
 })
 
 const mousePoint = computed(() => {
-  if (!props.containerRef) {
-    return { x: 0, y: 0, dir: { cx: 0, cy: 0 } }
-  }
-
-  const container = props.containerRef.getBoundingClientRect()
-
   let rawX = store.cursorPosition.x
   let rawY = store.cursorPosition.y
 
@@ -45,8 +37,8 @@ const mousePoint = computed(() => {
     rawY = snapState.snapPos.y
   }
 
-  const x = (rawX - container.left) + props.containerRef.scrollLeft
-  const y = (rawY - container.top) + props.containerRef.scrollTop
+  const x = (rawX - store.timelineRect.left) + store.timelineScrollLeft
+  const y = (rawY - store.timelineRect.top) + store.timelineScrollTop
 
   const dir = PORT_DIRECTIONS[snapState.targetPort ?? 'left']
 

--- a/src/stores/timelineStore.js
+++ b/src/stores/timelineStore.js
@@ -206,6 +206,8 @@ export const useTimelineStore = defineStore('timeline', () => {
 
     const activeTrackId = ref(null)
     const timelineScrollLeft = ref(0)
+    const timelineScrollTop = ref(0)
+    const timelineRect = ref({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 })
 
     const showCursorGuide = ref(false)
     const cursorCurrentTime = ref(0)
@@ -671,6 +673,8 @@ export const useTimelineStore = defineStore('timeline', () => {
     // ===================================================================================
 
     function setScrollLeft(val) { timelineScrollLeft.value = val }
+    function setScrollTop(val) { timelineScrollTop.value = val }
+    function setTimelineRect(width, height, top, right, bottom, left) { timelineRect.value = { width, height, top, left, right, bottom } }
     function setCursorTime(time) { cursorCurrentTime.value = Math.max(0, time) }
     function setCursorPosition(x, y) { cursorPosition.value = { x, y } }
     function toggleCursorGuide() { showCursorGuide.value = !showCursorGuide.value }
@@ -1880,12 +1884,12 @@ export const useTimelineStore = defineStore('timeline', () => {
 
     return {
         MAX_SCENARIOS,
-        systemConstants, isLoading, characterRoster, iconDatabase, tracks, connections, activeTrackId, timelineScrollLeft, globalDragOffset, draggingSkillData,
+        systemConstants, isLoading, characterRoster, iconDatabase, tracks, connections, activeTrackId, timelineScrollLeft, timelineScrollTop, timelineRect, globalDragOffset, draggingSkillData,
         selectedActionId, selectedLibrarySkillId, multiSelectedIds, clipboard, isCapturing, setIsCapturing, showCursorGuide, isBoxSelectMode, cursorCurrentTime, cursorPosition, snapStep,
         selectedAnomalyId, setSelectedAnomalyId, updateTrackGaugeEfficiency,
         teamTracksInfo, activeSkillLibrary, BASE_BLOCK_WIDTH, setBaseBlockWidth, formatTimeLabel, ZOOM_LIMITS, timeBlockWidth, ELEMENT_COLORS, getActionPositionInfo, getIncomingConnections, getCharacterElementColor, isActionSelected, hoveredActionId, setHoveredAction,
         fetchGameData, exportProject, importProject, exportShareString, importShareString, TOTAL_DURATION, selectTrack, changeTrackOperator, clearTrack, selectLibrarySkill, updateLibrarySkill, selectAction, updateAction,
-        addSkillToTrack, setDraggingSkill, setDragOffset, setScrollLeft, calculateGlobalSpData, calculateGaugeData, calculateGlobalStaggerData, updateTrackInitialGauge, updateTrackMaxGauge,
+        addSkillToTrack, setDraggingSkill, setDragOffset, setScrollLeft, setScrollTop, setTimelineRect, calculateGlobalSpData, calculateGaugeData, calculateGlobalStaggerData, updateTrackInitialGauge, updateTrackMaxGauge,
         removeConnection, updateConnection, updateConnectionPort, getColor, toggleCursorGuide, toggleBoxSelectMode, setCursorTime, setCursorPosition, toggleSnapStep, nudgeSelection,
         setMultiSelection, clearSelection, copySelection, pasteSelection, removeCurrentSelection, undo, redo, commitState,
         removeAnomaly, initAutoSave, loadFromBrowser, resetProject, selectedConnectionId, selectConnection, selectAnomaly, getAnomalyIndexById,


### PR DESCRIPTION
小幅性能优化
在store中保存`tracksContentRef`的`boundingRect`,`scrollTop`,`scrollLeft`,需要使用的时候直接从store中读取