### PR TITLE
Fix : 避免鼠标事件从ContextMenu穿透到时间轴

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -7,10 +7,14 @@ import { useI18n } from 'vue-i18n'
 const store = useTimelineStore()
 const { t } = useI18n({ useScope: 'global' })
 
-const menuStyle = computed(() => ({
-  left: `${store.contextMenu.x}px`,
-  top: `${store.contextMenu.y}px`
-}))
+const menuStyle = computed(() => {
+  const { x, y } = store.toViewportSpace(store.contextMenu.x, store.contextMenu.y)
+  return {
+    position: 'fixed',
+    left: `${x}px`,
+    top: `${y}px`
+  }
+})
 
 const targetAction = computed(() => {
   if (!store.contextMenu.targetId) return null
@@ -145,12 +149,19 @@ function handleAddCycleBoundary() {
 </script>
 
 <template>
+  <Teleport to="body">
   <div v-if="store.contextMenu.visible"
        class="custom-context-menu"
        :style="menuStyle"
        @click.stop
-       @contextmenu.prevent
-       @mousedown.stop>
+       @contextmenu.prevent.stop
+       @pointerdown.stop
+       @pointermove.stop
+       @pointerover.stop
+       @mousedown.stop
+       @mousemove.stop
+       @mouseover.stop
+       @wheel.stop>
 
     <template v-if="targetAction">
       <div class="menu-header">{{ targetAction.name }}</div>
@@ -354,6 +365,7 @@ function handleAddCycleBoundary() {
     </template>
 
   </div>
+  </Teleport>
 </template>
 
 <style scoped>


### PR DESCRIPTION
track-divider-handle优先级比ContextMenu高

<img width="414" height="288" alt="image" src="https://github.com/user-attachments/assets/dd2a8ceb-c715-4a8c-8865-be21dcc71ab9" />

把ContextMenu移到最上层
<img width="389" height="288" alt="image" src="https://github.com/user-attachments/assets/9bbdb8ff-5632-4880-ae8f-57d3e7ef9639" />
