### PR TITLE
Feat : 干员选择器新增职业分类筛选，修复干员属性/定位数据

### DIFF
--- a/src/components/TimelineGrid.vue
+++ b/src/components/TimelineGrid.vue
@@ -20,6 +20,7 @@ import { frameToTime, snapTimeToFrame, timeToFrame } from '@/utils/time.js'
 import { toLegacyDisplayType } from '@/utils/hitModel.js'
 import { getGearPiece, getEnemy, getOperator } from '@/data'
 import {
+  getGameClassName,
   getGameElementName,
   getGameAttributeName,
   getGameSlotTypeName,
@@ -342,6 +343,7 @@ const isSelectorVisible = ref(false)
 const targetTrackIndex = ref(null)
 const searchQuery = ref('')
 const filterElement = ref('ALL')
+const filterClass = ref('ALL')
 const isWeaponSelectorVisible = ref(false)
 const weaponTargetIndex = ref(null)
 const weaponSearchQuery = ref('')
@@ -871,6 +873,19 @@ const ELEMENT_FILTERS = computed(() => {
   ]
 })
 
+const CLASS_FILTERS = computed(() => {
+  locale.value
+  return [
+    { label: t('timelineGrid.classFilter.all'), value: 'ALL' },
+    { label: getGameClassName('guard', locale.value), value: 'guard' },
+    { label: getGameClassName('caster', locale.value), value: 'caster' },
+    { label: getGameClassName('defender', locale.value), value: 'defender' },
+    { label: getGameClassName('vanguard', locale.value), value: 'vanguard' },
+    { label: getGameClassName('striker', locale.value), value: 'striker' },
+    { label: getGameClassName('supporter', locale.value), value: 'supporter' },
+  ]
+})
+
 const OPERATOR_ELEMENT_ICON_MAP = {
   physical: '/icons/icon_element_physical.webp',
   heat: '/icons/icon_element_heat.webp',
@@ -893,6 +908,7 @@ function openCharacterSelector(index) {
   targetTrackIndex.value = index
   searchQuery.value = ''
   filterElement.value = 'ALL'
+  filterClass.value = 'ALL'
   isSelectorVisible.value = true
 }
 
@@ -990,6 +1006,8 @@ const operatorSelectorItems = computed(() => {
     rarity: Number(char.rarity) || 0,
     element: char.element || 'physical',
     elementName: getGameElementName(char.element, locale.value),
+    class: char.class || '',
+    className: getGameClassName(char.class, locale.value),
     weapon: char.weapon || '',
     weaponName: getGameWeaponTypeName(char.weapon, locale.value),
     searchTerms: [
@@ -997,6 +1015,7 @@ const operatorSelectorItems = computed(() => {
       char.id,
       char.slug,
       getGameElementName(char.element, locale.value),
+      getGameClassName(char.class, locale.value),
       getGameWeaponTypeName(char.weapon, locale.value),
     ].map(normalizeSearchText).filter(Boolean),
     raw: char,
@@ -1011,6 +1030,9 @@ const filteredListFlat = computed(() => {
   let list = operatorSelectorItems.value
   if (filterElement.value !== 'ALL') {
     list = list.filter(c => c.element === filterElement.value)
+  }
+  if (filterClass.value !== 'ALL') {
+    list = list.filter(c => c.class === filterClass.value)
   }
   if (searchQuery.value) {
     const q = normalizeSearchText(searchQuery.value)
@@ -3090,6 +3112,11 @@ onUnmounted(() => {
             {{ elm.label }}
           </button>
         </div>
+        <div class="class-filters">
+          <button v-for="cls in CLASS_FILTERS" :key="cls.value" class="ea-btn ea-btn--glass-cut" :class="{ 'is-active': filterClass === cls.value }" @click="filterClass = cls.value">
+            {{ cls.label }}
+          </button>
+        </div>
       </div>
       <div class="roster-scroll-container">
         <template v-for="group in rosterByRarity" :key="group.level">
@@ -4707,6 +4734,13 @@ body.capture-mode .davinci-range {
 }
 
 .element-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-width: 100%;
+}
+
+.class-filters {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;

--- a/src/data/operators/mifu.ts
+++ b/src/data/operators/mifu.ts
@@ -8,7 +8,7 @@ const sheet: OperatorSheet = {
   element: 'physical',
   finisherElement: 'physical',
   diveElement: 'physical',
-  class: 'striker',
+  class: 'guard',
   mainAttribute: 'strength',
   subAttribute: 'will',
   attributes: {

--- a/src/data/operators/rossi.ts
+++ b/src/data/operators/rossi.ts
@@ -4,7 +4,7 @@ const sheet: OperatorSheet = {
   gameId: 'ROSSI',
   rarity: 6,
   weapon: 'sword',
-  element: 'heat',
+  element: 'physical',
   finisherElement: 'physical',
   diveElement: 'physical',
   class: 'guard',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -277,12 +277,15 @@
       "gameTimeExpandTitle": "Expand Game Timeline"
     },
     "elementFilter": {
-      "all": "All",
+      "all": "All Elements",
       "blaze": "Heat",
       "cold": "Cryo",
       "emag": "Electric",
       "nature": "Nature",
       "physical": "Physical"
+    },
+    "classFilter": {
+      "all": "All Classes"
     },
     "equipmentDialog": {
       "allCategories": "All Categories",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -277,12 +277,15 @@
       "gameTimeExpandTitle": "Развернуть таймлайн"
     },
     "elementFilter": {
-      "all": "Все",
+      "all": "Все стихии",
       "blaze": "Огонь",
       "cold": "Холод",
       "emag": "Электро",
       "nature": "Природа",
       "physical": "Физ."
+    },
+    "classFilter": {
+      "all": "Все классы"
     },
     "equipmentDialog": {
       "allCategories": "Все категории",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -277,12 +277,15 @@
       "gameTimeExpandTitle": "展开游戏时间轴"
     },
     "elementFilter": {
-      "all": "全部",
+      "all": "全部属性",
       "blaze": "灼热",
       "cold": "寒冷",
       "emag": "电磁",
       "nature": "自然",
       "physical": "物理"
+    },
+    "classFilter": {
+      "all": "全部职业"
     },
     "equipmentDialog": {
       "allCategories": "全部分类",


### PR DESCRIPTION
- 新增职业筛选按钮行（先锋/近卫/重装/术师/突击/辅助），与属性筛选并列，支持AND组合筛选
- 属性筛选"全部"更名为"全部属性"，与"全部职业"对称
- 修复弭弗定位：突击 → 近卫
- 修复洛茜属性：灼热 → 物理