### PR TITLE
Feat : 添加连携窗口判断和显示功能

### DIFF
--- a/src/components/ActionItem.vue
+++ b/src/components/ActionItem.vue
@@ -105,16 +105,7 @@ function onDamageHitClick(hit) {
   emit('hit-click', hit.data)
 }
 
-// 连携冷却计算
-
-const currentTrack = computed(() => {
-  return store.tracks.find(t => t.actions?.some(a => a.instanceId === props.action.instanceId)) || null
-})
-
-const baseCooldown = computed(() => {
-  const resolved = store.compiledTimeline?.actionMap?.get(props.action.instanceId)
-  return Number(resolved?.node?.baseCooldown ?? props.action.baseCooldown ?? props.action.cooldown) || 0
-})
+// 冷却计算 — 使用编译器预计算的 effective cooldown，仅叠加运行时 sim 缩减
 
 const simCdReduction = computed(() => {
   const log = store.simLog || store.simulation?.simLog || []
@@ -123,35 +114,30 @@ const simCdReduction = computed(() => {
     .reduce((sum, entry) => sum + (Number(entry.payload?.reduction) || 0), 0)
 })
 
+/** Compiled effective cooldown (after passive stats), or null if not yet compiled.
+ *
+ *  Naming trap: `action.cooldown` 原本存的是技能面板原始冷却 (如 25s)，
+ *  但 compileScenario.normalizeAction 把 resolveEffectiveCooldown 的返回值
+ *  展开后覆盖了它 → 变成有效冷却 (如 20s)。原始值则移到新增的 `baseCooldown` 字段。
+ *  所以编译后 resolved.node.cooldown = 有效值，resolved.node.baseCooldown = 原始值。 */
+const compiledCooldown = computed(() => {
+  // NOTE: resolved.node !== props.action — 编译期创建了新对象。
+  // props.action.baseCooldown 为 undefined，必须读 actionMap。
+  const resolved = store.compiledTimeline?.actionMap?.get(props.action.instanceId)
+  const cd = resolved?.node?.cooldown
+  return typeof cd === 'number' ? cd : null
+})
+
 const effectiveComboCooldown = computed(() => {
-  const baseCd = baseCooldown.value
   if (props.action.type !== 'comboSkill') return 0
-  const track = currentTrack.value
-  const clamp = (val) => {
-    const num = Number(val) || 0
-    if (num < 0) return 0
-    if (num > 100) return 100
-    return num
-  }
-  const reduction = Math.max(
-      clamp(track?.stats?.combo_cd_reduction),
-      clamp(track?.stats?.link_cd_reduction),
-      clamp(track?.linkCdReduction),
-      clamp(store.systemConstants.linkCdReduction),
-  )
-  const flat = Math.max(0, Number(track?.stats?.combo_cd_reduction_flat) || 0)
-  const extMult = Math.max(0, Number(track?.stats?.combo_cd_external_mult ?? 1) || 1)
-  return Math.max(0, (baseCd - flat) * (1 - reduction / 100) * extMult - simCdReduction.value)
+  const compiled = compiledCooldown.value
+  return compiled != null ? Math.max(0, compiled - simCdReduction.value) : 0
 })
 
 const effectiveUltimateCooldown = computed(() => {
-  const baseCd = baseCooldown.value
   if (props.action.type !== 'ultimate') return 0
-  const track = store.tracks.find(t => t.actions?.some(a => a.instanceId === props.action.instanceId))
-  const pct = Math.max(0, Math.min(100, Number(track?.stats?.ult_cd_reduction) || 0))
-  const flat = Math.max(0, Number(track?.stats?.ult_cd_reduction_flat) || 0)
-  const extMult = Math.max(0, Number(track?.stats?.ult_cd_external_mult ?? 1) || 1)
-  return Math.max(0, (baseCd - flat) * (1 - pct / 100) * extMult - simCdReduction.value)
+  const compiled = compiledCooldown.value
+  return compiled != null ? Math.max(0, compiled - simCdReduction.value) : 0
 })
 
 // 主体样式计算

--- a/src/components/TimelineComboWindowBar.vue
+++ b/src/components/TimelineComboWindowBar.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { useTimelineStore } from '../stores/timelineStore.js'
+import { formatFrameCount } from '@/utils/time.js'
+
+defineProps({
+  trackId: { type: String, required: true },
+})
+
+const store = useTimelineStore()
+
+function formatDuration(time) {
+  if (time >= 1) return store.formatTimeLabel(time)
+  return formatFrameCount(time)
+}
+</script>
+
+<template>
+  <div
+    v-if="store.comboWindowLayouts?.get(trackId)?.length"
+    class="combo-window-bar-layer"
+  >
+    <div
+      v-for="(cw, cwIdx) in store.comboWindowLayouts.get(trackId)"
+      :key="`cw-${trackId}-${cwIdx}`"
+      class="combo-window-bar"
+      :style="{
+        left: `${store.timeToPx(cw.start)}px`,
+        width: `${store.timeToPx(cw.end) - store.timeToPx(cw.start)}px`,
+        '--cw-color': cw.color,
+      }"
+    >
+      <div class="cw-start-mark"></div>
+      <div class="cw-line"></div>
+      <div class="cw-end-mark"></div>
+      <span class="cw-duration">{{ formatDuration(cw.duration) }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.combo-window-bar-layer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 0;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.combo-window-bar {
+  position: absolute;
+  bottom: 0;
+  height: 2px;
+  display: flex;
+  align-items: center;
+  transform: translateY(7px);
+  pointer-events: none;
+}
+
+.cw-start-mark {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 8px;
+  background-color: var(--cw-color);
+}
+
+.cw-line {
+  flex-grow: 1;
+  height: 0;
+  border-bottom: 2px dashed var(--cw-color);
+}
+
+.cw-end-mark {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 8px;
+  background-color: var(--cw-color);
+}
+
+.cw-duration {
+  position: absolute;
+  left: 0;
+  top: 4px;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 1;
+  color: var(--cw-color);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+  white-space: nowrap;
+}
+</style>

--- a/src/components/TimelineGrid.vue
+++ b/src/components/TimelineGrid.vue
@@ -7,6 +7,7 @@ import ActionConnector from './ActionConnector.vue'
 import ConnectionPreview from './ConnectionPreview.vue'
 import GaugeOverlay from './GaugeOverlay.vue'
 import TimelineBuffLayer from './TimelineBuffLayer.vue'
+import TimelineComboWindowBar from './TimelineComboWindowBar.vue'
 import ContextMenu from './ContextMenu.vue'
 import StatDetailDialog from './StatDetailDialog.vue'
 import HitDamageDetailDialog from './HitDamageDetailDialog.vue'
@@ -3070,6 +3071,10 @@ onUnmounted(() => {
                   :class="{ 'is-moving': isDragStarted && store.isActionSelected(action.instanceId) }"
                 />
               </div>
+              <TimelineComboWindowBar
+                v-if="track.id && store.isOperatorEffectsVisible(index)"
+                :track-id="track.id"
+              />
               <div v-if="store.isOperatorEffectsVisible(index)" class="switch-marker-layer">
                 <div v-for="sw in store.switchEvents.filter(s => s.characterId === track.id)"
                      :key="sw.id"
@@ -4344,7 +4349,7 @@ body.capture-mode .davinci-range {
 .track-divider-handle {
   position: absolute;
   right: 0;
-  height: 6px;
+  height: 12px;
   transform: translateY(-50%);
   cursor: ns-resize;
   pointer-events: auto;

--- a/src/data/collect.ts
+++ b/src/data/collect.ts
@@ -23,6 +23,7 @@ import type {
   Segment,
   OperatorSheet,
   DamageElement,
+  EffectCondition
 } from './types';
 import { resolveLeveled, isTickGroup, createFinisherEntry, createDiveEntry } from './types';
 import type { TeamInstance, OperatorInstance, WeaponInstance, GearInstance } from '../types';
@@ -869,6 +870,60 @@ export function collectTriggerEffects(
             sourceSkillType: skillKey,
           });
         }
+      }
+
+      // Combo window triggers — inject comboWindow as a regular trigger
+      //  and auto-consume it when the combo skill is used.
+      for (const [skillKey, skill] of Object.entries(op.combatSkills)) {
+        const cw = skill.comboWindow;
+        if (!cw || skillKey !== 'comboSkill') continue;
+
+        const triggers = cw.triggers ?? (cw.trigger ? [cw.trigger] : []);
+        if (triggers.length === 0) continue;
+
+        const cdCondition: EffectCondition = { kind : "comboNotOnCooldown" };
+
+        // Build flat AND-condition array: operator condition(s) + comboNotOnCooldown.
+        const flatConds: EffectCondition[] = [];
+        if (cw.condition) {
+          if (Array.isArray(cw.condition)) flatConds.push(...cw.condition);
+          else flatConds.push(cw.condition);
+        }
+        flatConds.push(cdCondition);
+
+        const windowEffect: Effect = {
+          id: makeEffectId(operatorSlug, 'combo-window'),
+          name: 'comboWindow',
+          kind: 'status', // Maybe add an implicit 'comboWindow' kind is better, but status is enough for now.
+          target: 'owner',
+          duration: cw.duration,
+          condition: flatConds,
+          sourceGroup: 'operator',
+          hide: true,  // rendered via dedicated combo-window bar, not TimelineBuffLayer
+        };
+
+        for (const trigger of triggers) {
+          collected.push({
+            triggerEffect: { trigger, effects: [windowEffect] },
+            sourceSlotIndex: slotIndex,
+            sourceOperatorSlug: operatorSlug,
+            sourceSkillType: skillKey,
+          });
+        }
+
+        // Auto-consume window when the combo skill is used
+        collected.push({
+          triggerEffect: {
+            trigger: { kind: 'onActionStart', skillTypes: 'comboSkill', triggerScope: 'self' },
+            effects: [{
+              kind: 'consume',
+              operatorStatus: makeEffectId(operatorSlug, 'combo-window'),
+            }],
+          },
+          sourceSlotIndex: slotIndex,
+          sourceOperatorSlug: operatorSlug,
+          sourceSkillType: skillKey,
+        });
       }
     }
 

--- a/src/data/operators/akekuri.ts
+++ b/src/data/operators/akekuri.ts
@@ -216,6 +216,13 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        triggers: [
+          { kind: 'onStatusApplied', status: 'staggered', target: 'enemy', triggerScope: 'global' },
+          { kind: 'onStatusApplied', status: 'staggerNode', target: 'enemy', triggerScope: 'global' },
+        ],
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/alesh.ts
+++ b/src/data/operators/alesh.ts
@@ -311,6 +311,15 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusConsumed',
+          status: ['combustion', 'electrification', 'solidification', 'corrosion', 'originiumCrystals'],
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/antal.ts
+++ b/src/data/operators/antal.ts
@@ -250,6 +250,17 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['vulnerability', 'lift', 'knockdown', 'crush', 'breach',
+            'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        condition: { kind: 'enemyStatus', status: 'antal-battle-focus' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/arclight.ts
+++ b/src/data/operators/arclight.ts
@@ -259,6 +259,13 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        triggers: [
+          { kind: 'onStatusApplied', status: 'electrification', target: 'enemy', triggerScope: 'global' },
+          { kind: 'onStatusConsumed', status: 'electrification', target: 'enemy', triggerScope: 'global' }
+        ],
+        duration: 5,
+      },
       ultimateEnergyGain: 5,
       segments: [
         {

--- a/src/data/operators/ardelia.ts
+++ b/src/data/operators/ardelia.ts
@@ -220,6 +220,17 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+        condition: {
+          kind: 'not',
+          condition: {
+            kind: 'enemyStatus',
+            status: ['vulnerability', 'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction']
+          }
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/avywenna.ts
+++ b/src/data/operators/avywenna.ts
@@ -375,6 +375,11 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+        condition: { kind: 'enemyStatus', status: ['electricInfliction', 'electrification'] },
+        duration: 5,
+      },
       segments: [
         {
           duration: 0.7,

--- a/src/data/operators/camille.ts
+++ b/src/data/operators/camille.ts
@@ -409,6 +409,10 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onStatusConsumed', status: 'heatInfliction', target: 'enemy', triggerScope: 'global' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/chen-qianyu.ts
+++ b/src/data/operators/chen-qianyu.ts
@@ -220,6 +220,10 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/da-pan.ts
+++ b/src/data/operators/da-pan.ts
@@ -222,6 +222,11 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+        condition: { kind: 'enemyStatus', status: 'vulnerability', stacks: { compare: 'atLeast', count: 4 } },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/endministrator.ts
+++ b/src/data/operators/endministrator.ts
@@ -211,6 +211,10 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onHit', skillTypes: 'comboSkill', triggerScope: 'global' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/estella.ts
+++ b/src/data/operators/estella.ts
@@ -224,6 +224,10 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onStatusApplied', status: 'solidification', target: 'enemy', triggerScope: 'global' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/fluorite.ts
+++ b/src/data/operators/fluorite.ts
@@ -266,6 +266,20 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['cryoInfliction', 'natureInfliction'],
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        condition: {
+          kind: 'enemyStatus',
+          status: ['cryoInfliction', 'natureInfliction'],
+          stacks: { compare: 'atLeast', count: 2 }
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/gilberta.ts
+++ b/src/data/operators/gilberta.ts
@@ -224,6 +224,15 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['combustion', 'electrification', 'solidification', 'corrosion'],
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/laevatain.ts
+++ b/src/data/operators/laevatain.ts
@@ -449,6 +449,15 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['combustion', 'corrosion'],
+          target: 'enemy',
+          triggerScope: 'global',
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/last-rite.ts
+++ b/src/data/operators/last-rite.ts
@@ -298,6 +298,11 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onStatusApplied', status: 'cryoInfliction', target: 'enemy', triggerScope: 'global' },
+        condition: { kind: 'enemyStatus', status: 'cryoInfliction', stacks: { compare: 'atLeast', count: 3 } },
+        duration: 5,
+      },
       ultimateEnergyGain: 0,
       segments: [
         {

--- a/src/data/operators/lifeng.ts
+++ b/src/data/operators/lifeng.ts
@@ -287,6 +287,11 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+        condition: { kind: 'enemyStatus', status: ['vulnerability', 'breach'] },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/mifu.ts
+++ b/src/data/operators/mifu.ts
@@ -324,6 +324,11 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+        condition: { kind: 'enemyStatus', status: 'vulnerability', stacks: { compare: 'atLeast', count: 3 }, },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/perlica.ts
+++ b/src/data/operators/perlica.ts
@@ -196,6 +196,10 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/pogranichnik.ts
+++ b/src/data/operators/pogranichnik.ts
@@ -445,6 +445,15 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusConsumed',
+          status: 'vulnerability',
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/rossi.ts
+++ b/src/data/operators/rossi.ts
@@ -357,6 +357,22 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['vulnerability', 'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+          target: 'enemy',
+          triggerScope: 'global',
+        },
+        condition: [
+          { kind: 'enemyStatus', status: 'vulnerability' },
+          {
+            kind: 'enemyStatus',
+            status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction']
+          }
+        ],
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/tangtang.ts
+++ b/src/data/operators/tangtang.ts
@@ -417,6 +417,15 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['cryoInfliction', 'heatBurst', 'cryoBurst', 'electricBurst', 'natureBurst'],
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/wulfgard.ts
+++ b/src/data/operators/wulfgard.ts
@@ -287,6 +287,15 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusApplied',
+          status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+          target: 'enemy',
+          triggerScope: 'global'
+        },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/xaihi.ts
+++ b/src/data/operators/xaihi.ts
@@ -249,6 +249,16 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: {
+          kind: 'onStatusConsumed',
+          status: 'xaihi-auxiliary-crystal',
+          target: 'self',
+          triggerScope: 'global'
+        },
+        condition: { kind: 'not', condition: { kind: 'operatorStatus', status: 'xaihi-auxiliary-crystal' } },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/operators/yvonne.ts
+++ b/src/data/operators/yvonne.ts
@@ -352,6 +352,11 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+        condition: { kind: 'enemyStatus', status: 'solidification' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {
@@ -371,7 +376,7 @@ const sheet: OperatorSheet = {
                     ? [
                         {
                           id: 'yvonne-combo-ult-energy',
-                          kind: 'ultEnergyGain' as const,
+                          kind: 'ultEnergyGain',
                           value: 10,
                         },
                       ]

--- a/src/data/operators/zhuang-fangyi.ts
+++ b/src/data/operators/zhuang-fangyi.ts
@@ -636,6 +636,14 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      comboWindow: {
+        triggers: [
+          { kind: 'onFinalStrike', triggerScope: 'global' },
+          { kind: 'onFinisher', triggerScope: 'global' },
+        ],
+        condition: { kind: 'enemyStatus', status: 'electricInfliction' },
+        duration: 5,
+      },
       ultimateEnergyGain: 10,
       segments: [
         {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -206,12 +206,17 @@ export interface EnemyStaggeredCondition {
   kind: 'enemyStaggered';
 }
 
+export interface OperatorComboCdCondition {
+  kind: 'comboNotOnCooldown';
+}
+
 export type EffectCondition =
   | EnemyCondition
   | EnemyHpCondition
   | EnemyStaggeredCondition
   | OperatorCondition
   | OperatorHpCondition
+  | OperatorComboCdCondition
   | ActionLinkConsumedCondition
   | NegatedCondition
   | OrCondition;
@@ -815,6 +820,15 @@ export interface CombatSkillEntry {
   ultimateEnergyGain?: number;
   animationTime?: number;
   enhancementTime?: number;
+  /** Combo skill activation window. When the trigger fires, a window of `duration` seconds opens
+   *  during which this combo skill can be used. */
+  comboWindow?: {
+    trigger?: TriggerEvent;
+    /** Multiple triggers — all produce the same window effect. Use instead of `trigger`. */
+    triggers?: TriggerEvent[];
+    condition?: EffectCondition | EffectCondition[];
+    duration: number;
+  };
 }
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -509,6 +509,7 @@
       "blaze_burst": "Heat Burst",
       "emag_burst": "Electric Burst",
       "cold_burst": "Cryo Burst",
+      "comboWindow": "Combo Window",
       "nature_burst": "Nature Burst",
       "burning": "Combustion",
       "conductive": "Electrification",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -511,6 +511,7 @@
       "blaze_burst": "灼热爆发",
       "emag_burst": "电磁爆发",
       "cold_burst": "寒冷爆发",
+      "comboWindow": "连携窗口",
       "nature_burst": "自然爆发",
       "burning": "燃烧",
       "conductive": "导电",

--- a/src/simulation/adapters/projectOptimizerResult.ts
+++ b/src/simulation/adapters/projectOptimizerResult.ts
@@ -8,6 +8,7 @@ import { projectSpSeries } from "@/simulation/projection/projectSpSeries";
 import { projectStaggerSeries } from "@/simulation/projection/projectStaggerSeries";
 import { projectUltimateSeries } from "@/simulation/projection/projectUltimateSeries";
 import { projectActionBuffs } from "@/simulation/projection/projectActionBuffs";
+import { projectAllComboWindows } from "@/simulation/projection/projectComboWindows";
 import { resolveEffectDisplayKey } from "@/utils/effectDisplay";
 
 interface ProjectOptimizerResultInput {
@@ -391,6 +392,15 @@ export function projectOptimizerResult(input: ProjectOptimizerResultInput) {
     }
   }
 
+  const comboWindowLayouts =
+    operatorLog.length > 0 && tracks?.length
+      ? projectAllComboWindows(
+          operatorLog,
+          tracks.filter(t => t?.id).map(t => t.id),
+          duration,
+        )
+      : new Map<string, any>();
+
   return {
     simLog,
     operatorLog,
@@ -403,5 +413,6 @@ export function projectOptimizerResult(input: ProjectOptimizerResultInput) {
     enemyEffectLayout,
     enemyAfflictionViz,
     operatorEffectLayouts,
+    comboWindowLayouts,
   };
 }

--- a/src/simulation/engine/TriggerRegistry.ts
+++ b/src/simulation/engine/TriggerRegistry.ts
@@ -579,6 +579,8 @@ export class TriggerRegistry {
       const clamped = Math.min(reduction, remaining);
       if (clamped <= 0) continue;
 
+      ctx.state.getActor(targetTrackId).recordCdReduction(target.node.instanceId, clamped);
+
       ctx.simLog({
         type: 'CD_REDUCTION',
         time,

--- a/src/simulation/events/StaggerChangeHandler.ts
+++ b/src/simulation/events/StaggerChangeHandler.ts
@@ -82,6 +82,24 @@ export class StaggerChangeHandler implements EventHandler<StaggerChangeEvent> {
       },
     });
 
+    // Surface each stagger node as an internal enemy status so effects
+    // that watch for nodes (e.g. Akekuri's combo window) can activate via the
+    // standard onStatusApplied/Expire trigger pipeline.
+    if (nodeReachedIndex !== undefined && nodeEndTime !== undefined && !broken) {
+      ctx.queue.enqueue({
+        type: 'ENEMY_EFFECT_APPLY',
+        time: e.time,
+        kind: 'status',
+        id: 'staggerNode',
+        value: 0,
+        stacks: 1,
+        maxStacks: 1,
+        expiresAt: nodeEndTime,
+        sourceId: actor.id,
+        effect: { kind: 'status', hide: true },
+      }, 0);
+    }
+
     // Surface the break window as an internal enemy status so passive effects
     // gated on `condition: { kind: 'enemyStaggered' }` activate via the
     // standard onStatusApplied/Expire trigger pipeline.

--- a/src/simulation/events/effectDispatch.ts
+++ b/src/simulation/events/effectDispatch.ts
@@ -31,7 +31,7 @@ import type {
 } from '@/simulation/engine/types';
 import type { SimulationContext } from '@/simulation/engine/SimulationContext';
 import { resolveEffectDefaults, resolveEffectLifecycle } from '@/data/effectPresets';
-import type { ActorStats } from '@/simulation/compiler/types';
+import type { ResolvedAction, ActorStats } from '@/simulation/compiler/types';
 import { computeScalingBasis } from '@/data/stats';
 import { computeStats } from '@/data/stats/computeStats';
 import { resolveStatAttributes } from '@/data/collect';
@@ -247,6 +247,23 @@ export function evaluateEffectCondition(
   if (cond.kind === 'actionLinkConsumed') {
     if (!actionId) return false;
     return (ctx.getAction(actionId)?.consumedStacks?.link ?? 0) > 0;
+  }
+  if (cond.kind === 'comboNotOnCooldown') {
+    const actions = ctx.getAllActions();
+    // Find the last combo action on this track (descending by start time)
+    let lastCombo: ResolvedAction | undefined;
+    for (let i = actions.length - 1; i >= 0; i--) {
+      const a = actions[i]!;
+      if (a.trackId === sourceTrackId && a.node.type === 'comboSkill' && !a.node.isDisabled && a.realStartTime <= time) {
+        if (!lastCombo || a.realStartTime > lastCombo.realStartTime) lastCombo = a;
+      }
+    }
+    if (!lastCombo) return true;
+    const startTime = lastCombo.realStartTime;
+    const cd = lastCombo.node.cooldown ?? 0;
+    const cdReduction = ctx.state.getActor(sourceTrackId).getCdReduction(lastCombo.id);
+    const cooldownEnd = startTime + cd - cdReduction;
+    return time >= cooldownEnd;
   }
   if (cond.kind === 'enemyStaggered') {
     return ctx.state.enemy.isBroken(time);

--- a/src/simulation/projection/projectComboWindows.ts
+++ b/src/simulation/projection/projectComboWindows.ts
@@ -1,0 +1,116 @@
+/**
+ * Extract combo window segments from the operator log for track-row
+ * bottom-bar rendering (similar to combo skill cooldown bar style).
+ *
+ * Combo windows are `OPERATOR_EFFECT_APPLY` events whose id ends with `combo-window`
+ * (the stable programmatic identifier set by collect.ts).
+ * They are NOT rendered through TimelineBuffLayer — instead they get a dedicated
+ * thin horizontal bar at the bottom of the track row.
+ *
+ * Merging is handled implicitly by the state-machine approach:
+ * multiple APPLY events before an EXPIRE are collapsed into a single window
+ * from the first apply to the expire.
+ */
+import type {
+  OperatorStateEvent,
+  OperatorEffectApplyEvent,
+  OperatorEffectExpireEvent,
+} from '@/simulation/engine/types';
+
+export interface ComboWindowSegment {
+  start: number;
+  end: number;
+  duration: number;
+  color: string;
+}
+
+export type ComboWindowLayout = ComboWindowSegment[];
+
+const COMBO_WINDOW_COLOR = '#fdd900'; // gold — matches comboSkill theme color
+
+type Marker = { kind: 'apply' | 'expire'; time: number };
+
+export function projectComboWindows(
+  operatorLog: OperatorStateEvent[],
+  trackId: string,
+  maxTime: number,
+): ComboWindowLayout {
+  const markers: Marker[] = [];
+
+  for (const e of operatorLog) {
+    if (e.type === 'OPERATOR_EFFECT_APPLY' && (e as OperatorEffectApplyEvent).targetTrackId === trackId) {
+      const ae = e as OperatorEffectApplyEvent;
+      if (ae.id.endsWith('combo-window')) {
+        markers.push({ kind: 'apply', time: ae.time });
+      }
+    }
+    if (e.type === 'OPERATOR_EFFECT_EXPIRE' && (e as OperatorEffectExpireEvent).targetTrackId === trackId) {
+      const ee = e as OperatorEffectExpireEvent;
+      if (ee.id.endsWith('combo-window')) {
+        markers.push({ kind: 'expire', time: ee.time });
+      }
+    }
+  }
+
+  if (markers.length === 0) return [];
+
+  // Stable sort: apply then expire at the same timestamp (consume+reapply in same tick)
+  markers.sort((a, b) => {
+    if (a.time !== b.time) return a.time - b.time;
+    return a.kind === 'expire' ? -1 : 1; // expire before apply at same tick
+  });
+
+  const segments: ComboWindowSegment[] = [];
+  let windowStart: number | null = null;
+
+  for (const m of markers) {
+    if (m.kind === 'apply') {
+      if (windowStart == null) windowStart = m.time;
+      // else: window already open — skip this apply (it's a refresh/restack)
+    } else {
+      // expire
+      if (windowStart != null) {
+        const end = Math.min(m.time, maxTime);
+        if (end > windowStart) {
+          segments.push({
+            start: windowStart,
+            end,
+            duration: end - windowStart,
+            color: COMBO_WINDOW_COLOR,
+          });
+        }
+        windowStart = null;
+      }
+    }
+  }
+
+  // Close any window still open at end of timeline
+  if (windowStart != null && maxTime > windowStart) {
+    segments.push({
+      start: windowStart,
+      end: maxTime,
+      duration: maxTime - windowStart,
+      color: COMBO_WINDOW_COLOR,
+    });
+  }
+
+  return segments;
+}
+
+/**
+ * Build a map of trackId → ComboWindowLayout for all tracks.
+ */
+export function projectAllComboWindows(
+  operatorLog: OperatorStateEvent[],
+  trackIds: string[],
+  maxTime: number,
+): Map<string, ComboWindowLayout> {
+  const result = new Map<string, ComboWindowLayout>();
+  for (const trackId of trackIds) {
+    const layout = projectComboWindows(operatorLog, trackId, maxTime);
+    if (layout.length > 0) {
+      result.set(trackId, layout);
+    }
+  }
+  return result;
+}

--- a/src/simulation/state/ActorState.ts
+++ b/src/simulation/state/ActorState.ts
@@ -6,6 +6,8 @@ export class ActorState implements BaseGameState<ActorSnapshot> {
   public effects: EffectManager;
   private gauge: number;
   private maxGauge: number;
+  /** Accumulated runtime CD reduction per actionId (written by TriggerRegistry). */
+  private cdReductions = new Map<string, number>();
 
   constructor(public readonly snapshotData: ActorSnapshot) {
     this.effects = new EffectManager();
@@ -38,6 +40,15 @@ export class ActorState implements BaseGameState<ActorSnapshot> {
     const next = this.gauge + amount;
     this.gauge = Math.max(0, Math.min(next, this.maxGauge || next));
     return this.gauge;
+  }
+
+  recordCdReduction(actionId: string, amount: number) {
+    const prev = this.cdReductions.get(actionId) ?? 0;
+    this.cdReductions.set(actionId, prev + amount);
+  }
+
+  getCdReduction(actionId: string): number {
+    return this.cdReductions.get(actionId) ?? 0;
   }
 
   snapshot(): ActorSnapshot {

--- a/src/stores/timelineStore.js
+++ b/src/stores/timelineStore.js
@@ -4959,6 +4959,10 @@ export const useTimelineStore = defineStore('timeline', () => {
         return optimizerProjection.value.operatorEffectLayouts
     })
 
+    const comboWindowLayouts = computed(() => {
+        return optimizerProjection.value.comboWindowLayouts
+    })
+
     const timeContext = computed(() => compiledTimeline.value?.timeContext || null);
 
     const globalExtensions = computed(() => {
@@ -5691,6 +5695,7 @@ export const useTimelineStore = defineStore('timeline', () => {
         enemyEffectLayout,
         enemyAfflictionViz,
         operatorEffectLayouts,
+        comboWindowLayouts,
         gaugeSeriesByTrackId,
         simLog,
         operatorLog,


### PR DESCRIPTION
AI 总结：

## Feat: 连携窗口触发/显示 + 冷却缩减重构

### 连携窗口

为 25 名干员的 `comboSkill` 添加 `comboWindow` 配置，定义连携窗口的触发条件和持续时间。窗口打开时在技能时间轴对应 track 上渲染专用进度条，连携技使用后自动消耗窗口。

**数据层**
- `src/data/types.ts` — 新增 `CombatSkillEntry.comboWindow` 字段（trigger/triggers、condition、duration）、`OperatorComboCdCondition` 条件类型
- `src/data/collect.ts` — 将 comboWindow 注入为 trigger effect（`kind: 'status'`、`hide: true`），并注册 auto-consume（`onActionStart → consume`）
- `src/data/operators/*.ts` — 25 干员 combo window 配置，重装干员除外

**模拟层**
- `src/simulation/events/StaggerChangeHandler.ts` — staggerNode 作为敌人内部状态，供 onStatusApplied 触发
- `src/simulation/events/effectDispatch.ts` — 新增 `comboNotOnCooldown` 条件：连携技冷却中不打开窗口

**投影与渲染**
- `src/simulation/projection/projectComboWindows.ts` — 从 sim log 提取 apply/expire 事件，投影为时间段
- `src/simulation/adapters/projectOptimizerResult.ts` — 接入 comboWindowLayouts
- `src/components/TimelineComboWindowBar.vue` — 连携窗口进度条组件
- `src/components/TimelineGrid.vue` — 挂载 TimelineComboWindowBar
- `src/stores/timelineStore.js` — `comboWindowLayouts` 计算属性

### 冷却缩减

**旧版问题**

ActionItem 和编译器各自维护一份相同的冷却缩减公式。渲染层读 `action.baseCooldown`（原始值），重新计算 `(baseCd - flat) * (1 - pct/100) * extMult`，公式和 `compileScenario.ts` 的 `resolveEffectiveCooldown` 完全一致。

**新版**

- 渲染层只读 `action.cooldown`（编译器已折算的有效冷却），仅扣减运行时冷却缩减
- 公式归编译器单一维护，渲染层不重算
- 运行时冷却缩减记录到 `ActorState`，`TriggerRegistry` 通过 `ctx.state.getActor(id).recordCdReduction()` 操作，`comboNotOnCooldown` 条件通过 `ctx.state.getActor(id).getCdReduction()` 读取

**文件**
- `src/components/ActionItem.vue` — 公式去重，删除 `currentTrack`/`baseCooldown` computed，`effectiveComboCooldown`/`effectiveUltimateCooldown` 统一为 `compiledCooldown - simCdReduction`
- `src/simulation/state/ActorState.ts` — 新增 `cdReductions` Map + `recordCdReduction`/`getCdReduction` 方法
- `src/simulation/engine/TriggerRegistry.ts` — 将冷却缩减写入 ActorState

### UI
- 调高 track-divider-handle 高度（6px → 12px），便于鼠标选中
