### PR TITLE
Feat : 技能不满足前置条件时进行警告

### DIFF
--- a/src/components/ActionItem.vue
+++ b/src/components/ActionItem.vue
@@ -720,7 +720,7 @@ function handleActionDragStart(startPos, port) {
   right: 2px;
   color: #ff4d4f;
   pointer-events: auto;
-  cursor: help;
+  cursor: default;
 }
 
 .action-item-content {

--- a/src/components/ActionItem.vue
+++ b/src/components/ActionItem.vue
@@ -140,6 +140,28 @@ const effectiveUltimateCooldown = computed(() => {
   return compiled != null ? Math.max(0, compiled - simCdReduction.value) : 0
 })
 
+/** Add a warning mark for any unmet prerequisites. */
+const requisiteWarning = computed(() => {
+  return store.requisiteWarnings?.get(props.action.instanceId) ?? null
+})
+
+const requisiteTitle = computed(() => {
+  const w = requisiteWarning.value
+  if (!w) return ''
+  // Format the number with a maximum of 3 decimal places, omitting redundant trailing zeros.
+  const fmt = n => Number(n.toFixed(3)).toString()
+  if (w.kind === 'combo') return t('actionItem.requisiteTitle.comboWindow')
+  if (w.kind === 'sp') return t('actionItem.requisiteTitle.spInsufficient', {
+    need: fmt(w.need ?? 0),
+    current: fmt(w.current ?? 0)
+  })
+  if (w.kind === 'gauge') return t('actionItem.requisiteTitle.gaugeInsufficient', {
+    need: fmt(w.need ?? 0),
+    current: fmt(w.current ?? 0)
+  })
+  return ''
+})
+
 // 主体样式计算
 const PERFECT_LINK_STATUS_IDS = new Set([
   'rossi-combo-perfect-timing-satisfied',
@@ -613,6 +635,14 @@ function handleActionDragStart(startPos, port) {
       </svg>
     </div>
 
+    <div v-if="showDecorations && requisiteWarning" class="status-icon warn-icon" :title="requisiteTitle">
+      <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+        <line x1="12" y1="9" x2="12" y2="13"></line>
+        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+      </svg>
+    </div>
+
     <template v-if="showDecorations && action.type === 'ultimate' && !action.isDisabled">
       <div class="ultimate-side-bar left-bar" :style="{ backgroundColor: themeColor }"></div>
       <div class="ultimate-side-bar right-bar" :style="{ backgroundColor: themeColor }"></div>
@@ -685,6 +715,12 @@ function handleActionDragStart(startPos, port) {
 }
 .mute-icon {
   right: 2px;
+}
+.warn-icon {
+  right: 2px;
+  color: #ff4d4f;
+  pointer-events: auto;
+  cursor: help;
 }
 
 .action-item-content {

--- a/src/components/TimelineComboWindowBar.vue
+++ b/src/components/TimelineComboWindowBar.vue
@@ -1,12 +1,14 @@
 <script setup>
 import { useTimelineStore } from '../stores/timelineStore.js'
 import { formatFrameCount } from '@/utils/time.js'
+import { useI18n } from 'vue-i18n'
 
 defineProps({
   trackId: { type: String, required: true },
 })
 
 const store = useTimelineStore()
+const { t } = useI18n({ useScope: 'global' })
 
 function formatDuration(time) {
   if (time >= 1) return store.formatTimeLabel(time)
@@ -22,7 +24,8 @@ function formatDuration(time) {
     <div
       v-for="(cw, cwIdx) in store.comboWindowLayouts.get(trackId)"
       :key="`cw-${trackId}-${cwIdx}`"
-      class="combo-window-bar"
+      :class="['combo-window-bar', { 'perfect-timing-bar': cw.perfectTiming }]"
+      :title="cw.perfectTiming ? t('effects.name.perfectTiming') : t('effects.name.comboWindow')"
       :style="{
         left: `${store.timeToPx(cw.start)}px`,
         width: `${store.timeToPx(cw.end) - store.timeToPx(cw.start)}px`,
@@ -32,7 +35,7 @@ function formatDuration(time) {
       <div class="cw-start-mark"></div>
       <div class="cw-line"></div>
       <div class="cw-end-mark"></div>
-      <span class="cw-duration">{{ formatDuration(cw.duration) }}</span>
+      <span class="cw-duration-text">{{ formatDuration(cw.duration) }}</span>
     </div>
   </div>
 </template>
@@ -55,7 +58,7 @@ function formatDuration(time) {
   display: flex;
   align-items: center;
   transform: translateY(7px);
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .cw-start-mark {
@@ -74,6 +77,45 @@ function formatDuration(time) {
   border-bottom: 2px dashed var(--cw-color);
 }
 
+.perfect-timing-bar .cw-line {
+  position: relative;
+  height: 2px;
+  border-bottom: none;
+  background: repeating-linear-gradient(
+      90deg,
+      var(--cw-color) 0,
+      var(--cw-color) 4px,
+      transparent 4px,
+      transparent 8px
+  );
+  background-size: 8px 100%;
+  animation:
+      dash-flow 0.5s linear infinite;
+}
+
+@keyframes dash-flow {
+  from { background-position-x: 0; }
+  to   { background-position-x: 8px; }
+}
+
+.perfect-timing-bar .cw-line::after {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--cw-color);
+  animation:
+    move-along-path 1.5s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@keyframes move-along-path {
+  0%   { left: 0; }
+  100% { left: calc(100% - 4px); }
+}
+
 .cw-end-mark {
   position: absolute;
   right: 0;
@@ -84,7 +126,7 @@ function formatDuration(time) {
   background-color: var(--cw-color);
 }
 
-.cw-duration {
+.cw-duration-text {
   position: absolute;
   left: 0;
   top: 4px;

--- a/src/data/collect.ts
+++ b/src/data/collect.ts
@@ -878,31 +878,32 @@ export function collectTriggerEffects(
         const cw = skill.comboWindow;
         if (!cw || skillKey !== 'comboSkill') continue;
 
-        const triggers = cw.triggers ?? (cw.trigger ? [cw.trigger] : []);
-        if (triggers.length === 0) continue;
+        const triggers = cw.triggers;
+        if (!triggers || triggers.length === 0) continue;
 
         const cdCondition: EffectCondition = { kind : "comboNotOnCooldown" };
 
-        // Build flat AND-condition array: operator condition(s) + comboNotOnCooldown.
-        const flatConds: EffectCondition[] = [];
-        if (cw.condition) {
-          if (Array.isArray(cw.condition)) flatConds.push(...cw.condition);
-          else flatConds.push(cw.condition);
-        }
-        flatConds.push(cdCondition);
+        for (const entry of triggers) {
+          const trigger = entry.trigger;
+          // Build flat AND-condition array: operator condition(s) + comboNotOnCooldown.
+          const flatConds: EffectCondition[] = [];
+          if (entry.condition) {
+            if (Array.isArray(entry.condition)) flatConds.push(...entry.condition);
+            else flatConds.push(entry.condition);
+          }
+          flatConds.push(cdCondition);
 
-        const windowEffect: Effect = {
-          id: makeEffectId(operatorSlug, 'combo-window'),
-          name: 'comboWindow',
-          kind: 'status', // Maybe add an implicit 'comboWindow' kind is better, but status is enough for now.
-          target: 'owner',
-          duration: cw.duration,
-          condition: flatConds,
-          sourceGroup: 'operator',
-          hide: true,  // rendered via dedicated combo-window bar, not TimelineBuffLayer
-        };
+          const windowEffect: Effect = {
+            id: makeEffectId(operatorSlug, 'combo-window'),
+            name: 'comboWindow',
+            kind: 'status', // Maybe add an implicit 'comboWindow' kind is better, but status is enough for now.
+            target: 'owner',
+            duration: cw.duration,
+            condition: flatConds,
+            sourceGroup: 'operator',
+            hide: true,  // rendered via dedicated combo-window bar, not TimelineBuffLayer
+          };
 
-        for (const trigger of triggers) {
           collected.push({
             triggerEffect: { trigger, effects: [windowEffect] },
             sourceSlotIndex: slotIndex,

--- a/src/data/operators/akekuri.ts
+++ b/src/data/operators/akekuri.ts
@@ -218,8 +218,12 @@ const sheet: OperatorSheet = {
     comboSkill: {
       comboWindow: {
         triggers: [
-          { kind: 'onStatusApplied', status: 'staggered', target: 'enemy', triggerScope: 'global' },
-          { kind: 'onStatusApplied', status: 'staggerNode', target: 'enemy', triggerScope: 'global' },
+          {
+            trigger: { kind: 'onStatusApplied', status: 'staggered', target: 'enemy', triggerScope: 'global' },
+          },
+          {
+            trigger: { kind: 'onStatusApplied', status: 'staggerNode', target: 'enemy', triggerScope: 'global' },
+          },
         ],
         duration: 5,
       },

--- a/src/data/operators/alesh.ts
+++ b/src/data/operators/alesh.ts
@@ -312,12 +312,16 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusConsumed',
-          status: ['combustion', 'electrification', 'solidification', 'corrosion', 'originiumCrystals'],
-          target: 'enemy',
-          triggerScope: 'global'
-        },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusConsumed',
+              status: ['combustion', 'electrification', 'solidification', 'corrosion', 'originiumCrystals'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/antal.ts
+++ b/src/data/operators/antal.ts
@@ -251,14 +251,17 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['vulnerability', 'lift', 'knockdown', 'crush', 'breach',
-            'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
-          target: 'enemy',
-          triggerScope: 'global'
-        },
-        condition: { kind: 'enemyStatus', status: 'antal-battle-focus' },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['vulnerability', 'lift', 'knockdown', 'crush', 'breach',
+                'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/arclight.ts
+++ b/src/data/operators/arclight.ts
@@ -261,8 +261,12 @@ const sheet: OperatorSheet = {
     comboSkill: {
       comboWindow: {
         triggers: [
-          { kind: 'onStatusApplied', status: 'electrification', target: 'enemy', triggerScope: 'global' },
-          { kind: 'onStatusConsumed', status: 'electrification', target: 'enemy', triggerScope: 'global' }
+          {
+            trigger: { kind: 'onStatusApplied', status: 'electrification', target: 'enemy', triggerScope: 'global' },
+          },
+          {
+            trigger: { kind: 'onStatusConsumed', status: 'electrification', target: 'enemy', triggerScope: 'global' },
+          },
         ],
         duration: 5,
       },

--- a/src/data/operators/ardelia.ts
+++ b/src/data/operators/ardelia.ts
@@ -221,14 +221,18 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
-        condition: {
-          kind: 'not',
-          condition: {
-            kind: 'enemyStatus',
-            status: ['vulnerability', 'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction']
-          }
-        },
+        triggers: [
+          {
+            trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+            condition: {
+              kind: 'not',
+              condition: {
+                kind: 'enemyStatus',
+                status: ['vulnerability', 'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+              },
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/avywenna.ts
+++ b/src/data/operators/avywenna.ts
@@ -376,8 +376,12 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
-        condition: { kind: 'enemyStatus', status: ['electricInfliction', 'electrification'] },
+        triggers: [
+          {
+            trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: ['electricInfliction', 'electrification'] },
+          },
+        ],
         duration: 5,
       },
       segments: [

--- a/src/data/operators/camille.ts
+++ b/src/data/operators/camille.ts
@@ -410,7 +410,11 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onStatusConsumed', status: 'heatInfliction', target: 'enemy', triggerScope: 'global' },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusConsumed', status: 'heatInfliction', target: 'enemy', triggerScope: 'global' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/chen-qianyu.ts
+++ b/src/data/operators/chen-qianyu.ts
@@ -221,7 +221,11 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/da-pan.ts
+++ b/src/data/operators/da-pan.ts
@@ -223,8 +223,12 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
-        condition: { kind: 'enemyStatus', status: 'vulnerability', stacks: { compare: 'atLeast', count: 4 } },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: 'vulnerability', stacks: { compare: 'atLeast', count: 4 } },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/endministrator.ts
+++ b/src/data/operators/endministrator.ts
@@ -212,7 +212,11 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onHit', skillTypes: 'comboSkill', triggerScope: 'global' },
+        triggers: [
+          {
+            trigger: { kind: 'onHit', skillTypes: 'comboSkill', triggerScope: 'global' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/estella.ts
+++ b/src/data/operators/estella.ts
@@ -225,7 +225,11 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onStatusApplied', status: 'solidification', target: 'enemy', triggerScope: 'global' },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusApplied', status: 'solidification', target: 'enemy', triggerScope: 'global' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/fluorite.ts
+++ b/src/data/operators/fluorite.ts
@@ -267,17 +267,21 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['cryoInfliction', 'natureInfliction'],
-          target: 'enemy',
-          triggerScope: 'global'
-        },
-        condition: {
-          kind: 'enemyStatus',
-          status: ['cryoInfliction', 'natureInfliction'],
-          stacks: { compare: 'atLeast', count: 2 }
-        },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['cryoInfliction', 'natureInfliction'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+            condition: {
+              kind: 'enemyStatus',
+              status: ['cryoInfliction', 'natureInfliction'],
+              stacks: { compare: 'atLeast', count: 2 },
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/gilberta.ts
+++ b/src/data/operators/gilberta.ts
@@ -225,12 +225,16 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['combustion', 'electrification', 'solidification', 'corrosion'],
-          target: 'enemy',
-          triggerScope: 'global'
-        },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['combustion', 'electrification', 'solidification', 'corrosion'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/laevatain.ts
+++ b/src/data/operators/laevatain.ts
@@ -450,12 +450,16 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['combustion', 'corrosion'],
-          target: 'enemy',
-          triggerScope: 'global',
-        },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['combustion', 'corrosion'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/last-rite.ts
+++ b/src/data/operators/last-rite.ts
@@ -299,8 +299,12 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onStatusApplied', status: 'cryoInfliction', target: 'enemy', triggerScope: 'global' },
-        condition: { kind: 'enemyStatus', status: 'cryoInfliction', stacks: { compare: 'atLeast', count: 3 } },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusApplied', status: 'cryoInfliction', target: 'enemy', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: 'cryoInfliction', stacks: { compare: 'atLeast', count: 3 } },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 0,

--- a/src/data/operators/lifeng.ts
+++ b/src/data/operators/lifeng.ts
@@ -288,8 +288,12 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
-        condition: { kind: 'enemyStatus', status: ['vulnerability', 'breach'] },
+        triggers: [
+          {
+            trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: ['vulnerability', 'breach'] },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/mifu.ts
+++ b/src/data/operators/mifu.ts
@@ -325,8 +325,12 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
-        condition: { kind: 'enemyStatus', status: 'vulnerability', stacks: { compare: 'atLeast', count: 3 }, },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusApplied', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: 'vulnerability', stacks: { compare: 'atLeast', count: 3 } },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/perlica.ts
+++ b/src/data/operators/perlica.ts
@@ -197,7 +197,11 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+        triggers: [
+          {
+            trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/pogranichnik.ts
+++ b/src/data/operators/pogranichnik.ts
@@ -446,12 +446,11 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusConsumed',
-          status: 'vulnerability',
-          target: 'enemy',
-          triggerScope: 'global'
-        },
+        triggers: [
+          {
+            trigger: { kind: 'onStatusConsumed', status: 'vulnerability', target: 'enemy', triggerScope: 'global' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/rossi.ts
+++ b/src/data/operators/rossi.ts
@@ -358,18 +358,33 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['vulnerability', 'heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
-          target: 'enemy',
-          triggerScope: 'global',
-        },
-        condition: [
-          { kind: 'enemyStatus', status: 'vulnerability' },
+        // "当有敌人同时处于破防和法术附着状态时可以发动"
+        // 实际上在有破防的情况下上法术附着，即便这个附着和之前的附着反应掉了变成异常也算
+        triggers: [
           {
-            kind: 'enemyStatus',
-            status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction']
-          }
+            trigger: {
+              kind: 'onStatusApplied',
+              status: 'vulnerability',
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+            condition: {
+              kind: 'enemyStatus',
+              status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+            },
+          },
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+            condition: {
+              kind: 'enemyStatus',
+              status: 'vulnerability',
+            },
+          },
         ],
         duration: 5,
       },

--- a/src/data/operators/rossi.ts
+++ b/src/data/operators/rossi.ts
@@ -402,6 +402,17 @@ const sheet: OperatorSheet = {
                       duration: 0.516,
                       hide: true,
                     },
+                    {
+                      // TODO 二段连携窗口，目前未将两个窗口和两段连携技对应起来
+                      //  后续需要考虑如何对应起来，以及如何与完美连携窗口配合展示？
+                      id: 'rossi-combo-window',
+                      name: 'comboWindow',
+                      kind: 'status',
+                      target: 'owner',
+                      duration: 5,
+                      sourceGroup: 'operator',
+                      hide: true,
+                    }
                   ],
                 },
                 {

--- a/src/data/operators/rossi.ts
+++ b/src/data/operators/rossi.ts
@@ -588,7 +588,7 @@ const sheet: OperatorSheet = {
               kind: 'status',
               target: 'self',
               duration: 2,
-              icon: '/operators/rossi/avatar.webp',
+              hide: true
             },
           ],
         },

--- a/src/data/operators/tangtang.ts
+++ b/src/data/operators/tangtang.ts
@@ -418,12 +418,16 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['cryoInfliction', 'heatBurst', 'cryoBurst', 'electricBurst', 'natureBurst'],
-          target: 'enemy',
-          triggerScope: 'global'
-        },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['cryoInfliction', 'heatBurst', 'cryoBurst', 'electricBurst', 'natureBurst'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/wulfgard.ts
+++ b/src/data/operators/wulfgard.ts
@@ -288,12 +288,16 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusApplied',
-          status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
-          target: 'enemy',
-          triggerScope: 'global'
-        },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusApplied',
+              status: ['heatInfliction', 'cryoInfliction', 'electricInfliction', 'natureInfliction'],
+              target: 'enemy',
+              triggerScope: 'global',
+            },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/xaihi.ts
+++ b/src/data/operators/xaihi.ts
@@ -250,13 +250,17 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: {
-          kind: 'onStatusConsumed',
-          status: 'xaihi-auxiliary-crystal',
-          target: 'self',
-          triggerScope: 'global'
-        },
-        condition: { kind: 'not', condition: { kind: 'operatorStatus', status: 'xaihi-auxiliary-crystal' } },
+        triggers: [
+          {
+            trigger: {
+              kind: 'onStatusConsumed',
+              status: 'xaihi-auxiliary-crystal',
+              target: 'self',
+              triggerScope: 'global',
+            },
+            condition: { kind: 'not', condition: { kind: 'operatorStatus', status: 'xaihi-auxiliary-crystal' } },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/yvonne.ts
+++ b/src/data/operators/yvonne.ts
@@ -353,8 +353,12 @@ const sheet: OperatorSheet = {
     },
     comboSkill: {
       comboWindow: {
-        trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
-        condition: { kind: 'enemyStatus', status: 'solidification' },
+        triggers: [
+          {
+            trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: 'solidification' },
+          },
+        ],
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/operators/zhuang-fangyi.ts
+++ b/src/data/operators/zhuang-fangyi.ts
@@ -638,10 +638,15 @@ const sheet: OperatorSheet = {
     comboSkill: {
       comboWindow: {
         triggers: [
-          { kind: 'onFinalStrike', triggerScope: 'global' },
-          { kind: 'onFinisher', triggerScope: 'global' },
+          {
+            trigger: { kind: 'onFinalStrike', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: 'electricInfliction' },
+          },
+          {
+            trigger: { kind: 'onFinisher', triggerScope: 'global' },
+            condition: { kind: 'enemyStatus', status: 'electricInfliction' },
+          },
         ],
-        condition: { kind: 'enemyStatus', status: 'electricInfliction' },
         duration: 5,
       },
       ultimateEnergyGain: 10,

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -823,10 +823,10 @@ export interface CombatSkillEntry {
   /** Combo skill activation window. When the trigger fires, a window of `duration` seconds opens
    *  during which this combo skill can be used. */
   comboWindow?: {
-    trigger?: TriggerEvent;
-    /** Multiple triggers — all produce the same window effect. Use instead of `trigger`. */
-    triggers?: TriggerEvent[];
-    condition?: EffectCondition | EffectCondition[];
+    triggers: {
+      trigger: TriggerEvent;
+      condition?: EffectCondition | EffectCondition[];
+    }[];
     duration: number;
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1012,6 +1012,11 @@
   "actionItem": {
     "damageHitTooltip": "Damage: {damage}",
     "lockedTitle": "Locked",
-    "disabledTitle": "Disabled"
+    "disabledTitle": "Disabled",
+    "requisiteTitle": {
+      "comboWindow": "Not in combo window",
+      "spInsufficient": "Insufficient SP, need {need}, current {current}",
+      "gaugeInsufficient": "Insufficient gauge, need {need}, current {current}"
+    }
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1014,6 +1014,11 @@
   "actionItem": {
     "damageHitTooltip": "伤害: {damage}",
     "lockedTitle": "位置已锁定",
-    "disabledTitle": "已禁用：不参与计算"
+    "disabledTitle": "已禁用：不参与计算",
+    "requisiteTitle": {
+      "comboWindow": "不在连携窗口内",
+      "spInsufficient": "技力不足，需要{need}，当前{current}",
+      "gaugeInsufficient": "终结技能量不足，需要{need}，当前{current}"
+    }
   }
 }

--- a/src/simulation/adapters/projectOptimizerResult.ts
+++ b/src/simulation/adapters/projectOptimizerResult.ts
@@ -9,6 +9,7 @@ import { projectStaggerSeries } from "@/simulation/projection/projectStaggerSeri
 import { projectUltimateSeries } from "@/simulation/projection/projectUltimateSeries";
 import { projectActionBuffs } from "@/simulation/projection/projectActionBuffs";
 import { projectAllComboWindows } from "@/simulation/projection/projectComboWindows";
+import { projectRequisiteWarnings } from "@/simulation/projection/projectRequisiteWarnings";
 import { resolveEffectDisplayKey } from "@/utils/effectDisplay";
 
 interface ProjectOptimizerResultInput {
@@ -401,6 +402,13 @@ export function projectOptimizerResult(input: ProjectOptimizerResultInput) {
         )
       : new Map<string, any>();
 
+  const requisiteWarnings = projectRequisiteWarnings(
+      tracks || [],
+      comboWindowLayouts,
+      spSeries,
+      gaugeSeriesByTrackId,
+  );
+
   return {
     simLog,
     operatorLog,
@@ -414,5 +422,6 @@ export function projectOptimizerResult(input: ProjectOptimizerResultInput) {
     enemyAfflictionViz,
     operatorEffectLayouts,
     comboWindowLayouts,
+    requisiteWarnings,
   };
 }

--- a/src/simulation/projection/projectComboWindows.ts
+++ b/src/simulation/projection/projectComboWindows.ts
@@ -16,12 +16,14 @@ import type {
   OperatorEffectApplyEvent,
   OperatorEffectExpireEvent,
 } from '@/simulation/engine/types';
+import { timeToFrame } from '@/utils/time';
 
 export interface ComboWindowSegment {
   start: number;
   end: number;
   duration: number;
   color: string;
+  perfectTiming?: boolean; // this segment is a perfect-timing overlay
 }
 
 export type ComboWindowLayout = ComboWindowSegment[];
@@ -34,19 +36,20 @@ export function projectComboWindows(
   operatorLog: OperatorStateEvent[],
   trackId: string,
   maxTime: number,
+  suffix = 'combo-window',
 ): ComboWindowLayout {
   const markers: Marker[] = [];
 
   for (const e of operatorLog) {
     if (e.type === 'OPERATOR_EFFECT_APPLY' && (e as OperatorEffectApplyEvent).targetTrackId === trackId) {
       const ae = e as OperatorEffectApplyEvent;
-      if (ae.id.endsWith('combo-window')) {
+      if (ae.id.endsWith(suffix)) {
         markers.push({ kind: 'apply', time: ae.time });
       }
     }
     if (e.type === 'OPERATOR_EFFECT_EXPIRE' && (e as OperatorEffectExpireEvent).targetTrackId === trackId) {
       const ee = e as OperatorEffectExpireEvent;
-      if (ee.id.endsWith('combo-window')) {
+      if (ee.id.endsWith(suffix)) {
         markers.push({ kind: 'expire', time: ee.time });
       }
     }
@@ -99,18 +102,61 @@ export function projectComboWindows(
 
 /**
  * Build a map of trackId → ComboWindowLayout for all tracks.
+ * Perfect-timing windows are split into the combo window layout — they appear
+ * as sub-segments within the main window, not as separate bars.
  */
 export function projectAllComboWindows(
   operatorLog: OperatorStateEvent[],
   trackIds: string[],
   maxTime: number,
 ): Map<string, ComboWindowLayout> {
-  const result = new Map<string, ComboWindowLayout>();
+  const comboWindows = new Map<string, ComboWindowLayout>();
   for (const trackId of trackIds) {
-    const layout = projectComboWindows(operatorLog, trackId, maxTime);
-    if (layout.length > 0) {
-      result.set(trackId, layout);
-    }
+    const raw = projectComboWindows(operatorLog, trackId, maxTime, 'combo-window');
+    const pt = projectComboWindows(operatorLog, trackId, maxTime, 'combo-perfect-timing');
+    const layout = mergeWithPerfectTiming(raw, pt);
+    if (layout.length > 0) comboWindows.set(trackId, layout);
   }
-  return result;
+  return comboWindows;
+}
+
+/**
+ * Split combo window segments where perfect-timing overlaps, inserting
+ * perfectTiming-flagged sub-segments.
+ */
+function mergeWithPerfectTiming(
+  combo: ComboWindowSegment[],
+  perfect: ComboWindowSegment[],
+): ComboWindowSegment[] {
+  if (perfect.length === 0) return combo;
+
+  const times = new Set<number>();
+  for (const s of combo) { times.add(s.start); times.add(s.end); }
+  for (const s of perfect) { times.add(s.start); times.add(s.end); }
+  const sorted = [...times].sort((a, b) => a - b);
+
+  const segments: ComboWindowSegment[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    const start = sorted[i - 1]!;
+    const end = sorted[i]!;
+    // Skip if both ends land on the same frame — no real duration
+    if (timeToFrame(start) === timeToFrame(end)) continue;
+
+    const inCombo = combo.some(s =>
+        timeToFrame(start) >= timeToFrame(s.start) && timeToFrame(end) <= timeToFrame(s.end));
+    const inPerfect = perfect.some(s =>
+        timeToFrame(start) >= timeToFrame(s.start) && timeToFrame(end) <= timeToFrame(s.end));
+    if (!inCombo && !inPerfect) continue;
+    // Only perfect-timing within combo windows (not standalone)
+    if (inPerfect && !inCombo) continue;
+
+    segments.push({
+      start, end,
+      duration: end - start,
+      color: COMBO_WINDOW_COLOR,
+      perfectTiming: inPerfect ? true : undefined,
+    });
+  }
+
+  return segments;
 }

--- a/src/simulation/projection/projectRequisiteWarnings.ts
+++ b/src/simulation/projection/projectRequisiteWarnings.ts
@@ -1,0 +1,146 @@
+import { getOperator } from '@/data';
+import type { SpPoint } from './projectSpSeries';
+import type { GaugePoint } from './projectUltimateSeries';
+import { snapTimeToFrame } from '@/utils/time';
+import type { ComboWindowLayout } from './projectComboWindows';
+
+/**
+ * A skill that cannot execute because its prerequisite is unmet.
+ * - `kind`: which resource or window is lacking
+ * - `need` / `current`: the required and current values (sp / gauge)
+ */
+export interface RequisiteWarning {
+  kind: 'combo' | 'sp' | 'gauge';
+  need?: number;
+  current?: number;
+}
+
+interface TrackData {
+  id?: string;
+  actions?: {
+    isDisabled?: boolean;
+    startTime?: number;
+    type?: string;
+    instanceId?: string;
+    spCost?: number;
+    gaugeCost?: number;
+  }[];
+  operatorStatus?: {
+    ultimateEnergyCostReduction?: number;
+  };
+}
+
+/** Binary-search SP value just before `time`.
+ *  Same-frame hours have two points (pre-deduction, post-deduction).
+ *  `actionId` identifies which deduction belongs to this action. */
+function spAtTime(series: SpPoint[], time: number, actionId?: string): number {
+  if (!series.length) return 0;
+  if (time <= 0) return Number(series[0]!.sp) || 0;
+  let lo = 0;
+  let hi = series.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (snapTimeToFrame(series[mid]!.time) <= time) lo = mid;
+    else hi = mid - 1;
+  }
+  // If this is the deduction point for our action, back up to the pre-deduction point
+  if (actionId && lo > 0 && (series[lo] as any).actionId === actionId) lo--;
+  return Number(series[lo]!.sp) || 0;
+}
+
+/** Binary-search gauge value just before `time`.
+ *  Same-frame hours have two points (pre-consumption, post-consumption). */
+function gaugeAtTime(series: GaugePoint[], time: number): number {
+  if (!series.length) return 0;
+  if (time <= 0) return Number(series[0]!.val) || 0;
+  let lo = 0;
+  let hi = series.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (snapTimeToFrame(series[mid]!.time) <= time) lo = mid;
+    else hi = mid - 1;
+  }
+  // If the point at this time is post-consumption, back up to the pre-consumption point
+  while (lo > 0 && snapTimeToFrame(series[lo - 1]!.time) === snapTimeToFrame(series[lo]!.time)) lo--;
+  return Number(series[lo]!.val) || 0;
+}
+
+/**
+ * Build a map of actionId → RequisiteWarning for all skill blocks
+ * that cannot execute because their prerequisites are unmet.
+ *
+ * Three checks, one per skill type:
+ * - comboSkill  → must overlap a combo window (if the operator has one)
+ * - battleSkill → must have enough SP at start time
+ * - ultimate     → must have enough gauge at start time
+ *
+ * Disabled actions (isDisabled) are skipped entirely.
+ * Combo checks use frame-snapped times to avoid floating-point drift
+ * when the action's stored startTime differs from the expire event that
+ * closed the window.
+ */
+export function projectRequisiteWarnings(
+  tracks: TrackData[],
+  comboWindowLayouts: Map<string, ComboWindowLayout>,
+  spSeries: SpPoint[],
+  gaugeSeriesByTrackId: Map<string, GaugePoint[]>,
+): Map<string, RequisiteWarning> {
+  const warnings = new Map<string, RequisiteWarning>();
+
+  for (const track of tracks) {
+    const tid = track.id;
+    if (!tid || !track.actions) continue;
+
+    // Determine once per track — does this operator define a comboWindow?
+    const hasComboWindow = !!(track.id && getOperator(track.id)?.combatSkills?.comboSkill?.comboWindow);
+    const gaugeSeries = gaugeSeriesByTrackId.get(tid) ?? [];
+    const comboWindowLayout = comboWindowLayouts.get(tid) ?? [];
+
+    for (const a of track.actions) {
+      if (a.isDisabled || !a.instanceId) continue;
+      // TODO Some times are frame-snapped, others not — comparison breaks.
+      //  Solutions besides sprinkling snapTimeToFrame everywhere?
+      const start = snapTimeToFrame(a.startTime ?? 0);
+
+      // ── Combo skill: must overlap a combo window ────────────────────
+      if (a.type === 'comboSkill') {
+        if (!hasComboWindow) continue;
+        if (!comboWindowLayout.some(seg =>
+            start >= snapTimeToFrame(seg.start) &&
+            start <= snapTimeToFrame(seg.end))) {
+          warnings.set(a.instanceId, { kind: 'combo' });
+        }
+        continue;
+      }
+
+      // ── Battle skill: SP at action start ≥ spCost ───────────────────
+      if (a.type === 'battleSkill') {
+        const sc = Number(a.spCost) || 0;
+        if (sc > 0) {
+          const now = spAtTime(spSeries, start, a.instanceId);
+          if (now < sc) {
+            warnings.set(a.instanceId, { kind: 'sp', need: sc, current: now });
+          }
+        }
+        continue;
+      }
+
+      // ── Ultimate: gauge at action start ≥ gaugeCost ─────────────────
+      if (a.type === 'ultimate') {
+        const rawCost = Number(a.gaugeCost) || 0;
+        if (rawCost > 0) {
+          // TODO ultimateEnergyCostReduction is scattered — consolidate or just compute max once and always deduct to 0?
+          const reduction = Number(track?.operatorStatus?.ultimateEnergyCostReduction) || 0;
+          const effectiveCost = rawCost * (1 - Math.max(0, Math.min(reduction, 0.99)));
+          const now = gaugeAtTime(gaugeSeries, start);
+          if (now < effectiveCost) {
+            warnings.set(a.instanceId, { kind: 'gauge', need: effectiveCost, current: now });
+          }
+        }
+        continue;
+      }
+    }
+  }
+
+  return warnings;
+}

--- a/src/simulation/projection/projectSpSeries.ts
+++ b/src/simulation/projection/projectSpSeries.ts
@@ -1,17 +1,19 @@
 import type { GameSnapshot } from "@/simulation/state/types.ts";
 import type { SimLogEntry } from "@/simulation/events/event.types.ts";
 
+export interface SpPoint {
+  time: number;
+  sp: number;
+  actionId?: string;
+  change?: number;
+}
+
 export function projectSpSeries(
   simLog: SimLogEntry[],
   initialSnapshot: GameSnapshot,
   timelineDuration = 120
-) {
-  const spSeries: {
-    time: number;
-    sp: number;
-    actionId?: string;
-    change?: number;
-  }[] = [];
+): SpPoint[] {
+  const spSeries: SpPoint[] = [];
 
   let lastTime = 0;
   let lastValue = initialSnapshot.team.sp;

--- a/src/simulation/projection/projectUltimateSeries.ts
+++ b/src/simulation/projection/projectUltimateSeries.ts
@@ -1,12 +1,18 @@
 import type { SimLogEntry } from "@/simulation/events/event.types.ts";
 import type { GameSnapshot } from "@/simulation/state/types.ts";
 
+export interface GaugePoint {
+  time: number;
+  val: number;
+  ratio: number;
+}
+
 export function projectUltimateSeries(
   simLog: SimLogEntry[],
   initialSnapshot: GameSnapshot,
   actorId: string,
   timelineDuration = 120,
-) {
+): GaugePoint[] {
   const actor = initialSnapshot.actors.find((item) => item.id === actorId);
   if (!actor) {
     return [];
@@ -18,7 +24,7 @@ export function projectUltimateSeries(
     Math.min(Number(actor.resources?.gauge ?? actor.resources?.ultimateEnergy) || 0, maxGauge),
   );
 
-  const points = [
+  const points : GaugePoint[] = [
     { time: 0, val: currentGauge, ratio: currentGauge / maxGauge },
   ];
 

--- a/src/stores/timelineStore.js
+++ b/src/stores/timelineStore.js
@@ -4963,6 +4963,10 @@ export const useTimelineStore = defineStore('timeline', () => {
         return optimizerProjection.value.comboWindowLayouts
     })
 
+    const requisiteWarnings = computed(() => {
+        return optimizerProjection.value.requisiteWarnings
+    })
+
     const timeContext = computed(() => compiledTimeline.value?.timeContext || null);
 
     const globalExtensions = computed(() => {
@@ -5224,7 +5228,10 @@ export const useTimelineStore = defineStore('timeline', () => {
                 if (sourceTrack.id === trackId) {
                     // Costs are applied at action start.
                     if (action.gaugeCost > 0) {
-                        events.push({ time: snapTimeToFrame(action.startTime), change: -Number(action.gaugeCost) });
+                        // TODO ultimateEnergyCostReduction is scattered — consolidate or just compute max once and always deduct to 0?
+                        const costReduction = Number(track.operatorStatus?.ultimateEnergyCostReduction) || 0;
+                        const effectiveCost = action.gaugeCost * (1 - Math.max(0, Math.min(costReduction, 0.99)));
+                        events.push({ time: snapTimeToFrame(action.startTime), change: -effectiveCost });
                     }
                     // Self gauge gain is applied when the action ends.
                     if (action.gaugeGain > 0) {
@@ -5696,6 +5703,7 @@ export const useTimelineStore = defineStore('timeline', () => {
         enemyAfflictionViz,
         operatorEffectLayouts,
         comboWindowLayouts,
+        requisiteWarnings,
         gaugeSeriesByTrackId,
         simLog,
         operatorLog,


### PR DESCRIPTION
## Feat: 技能不满足前置条件时进行警告

新增 `projectRequisiteWarnings.ts`，在投影层检测技能释放的前提条件，渲染层在技能块右上角显示红色三角形警告。

**检测三项**：
- 连携技不在连携窗口内
- 战技释放时 SP 不足
- 终结技释放时能量不足

**文件**：
- `src/simulation/projection/projectRequisiteWarnings.ts` — 新增检测逻辑
- `src/simulation/adapters/projectOptimizerResult.ts` — 接入 requisiteWarnings
- `src/stores/timelineStore.js` — 暴露 `requisiteWarnings` computed
- `src/components/ActionItem.vue` — 右上角红色三角形警告 + tooltip
- `src/i18n/locales/zh-CN.json` — i18n
- `src/simulation/projection/projectSpSeries.ts` / `projectUltimateSeries.ts` —  使用其输出的sp/gauge时间轴序列二分查找对应时刻的能量值

---

## Fix: 修复洛茜连携技触发条件

洛茜的连携窗口触发条件从"破防和附着同时存在"改为"上破防时敌人有附着，或上附着时敌人有破防"，分别绑定到不同 trigger。因为附着和已经存在的附着进行反应转换为异常时，即便此时只剩下破防了，也能触发洛茜连携技。

**comboWindow 数据格式重构**：
- 旧：`{ trigger?, triggers?, condition?, duration }` — 所有 trigger 共享 condition
- 新：`{ triggers: [{ trigger, condition? }], duration }` — 每 trigger 独立 condition

**文件**：
- `src/data/types.ts` — comboWindow 类型改为 `triggers[{trigger, condition?}]`
- `src/data/collect.ts` — 每 trigger 独立构建 condition
- `src/data/operators/*.ts` — 25 干员数据迁移到新格式
- `src/data/operators/rossi.ts` — 拆为两个 trigger，各带互补条件

---

## Feat: 精准衔接UI显示效果调整，嵌入二段连携窗口显示

精准衔接（perfect-timing）窗口嵌入连携窗口 UI——不再在buff栏显示，而是将二段连携拆分为普通/精准衔接子段，精准衔接段显示流动虚线 + 滑动圆点。

**文件**：
- `projectComboWindows.ts` — 解析精准衔接effect，根据精准衔接窗口时间，将二段连携拆分为普通/精准衔接子段
- `TimelineComboWindowBar.vue` — 对于精准衔接窗口，显示流动虚线和滑动圆点。为连携窗口并添加tooltip，鼠标悬停显示”精准衔接“或”连携窗口“
- `src/data/operators/rossi.ts` — 精准衔接 status `hide: true`，不在buff栏显示