### PR TITLE
Reconcile the simulation engine with the optimizer (fix missing/wrong shared logic)

### DIFF
--- a/src/data/stats/computeStats.test.ts
+++ b/src/data/stats/computeStats.test.ts
@@ -21,8 +21,6 @@ describe('computeStats — dynamic attributeAtkPercent', () => {
       [{ stat: { modifier: 'attributeAtkPercent' }, value: 10 } as unknown as ResolvedStatModifier],
     );
 
-    // With zeroed base attributes the attribute bonus is exactly 1; a +10 attributeAtkPercent
-    // dynamic mod adds +0.10 to that multiplicative bonus (regression guard: this used to be dropped).
     expect(without.attack).toBe(1000);
     expect(withBuff.attack).toBe(1100);
     expect(withBuff.attack).toBeGreaterThan(without.attack);

--- a/src/data/stats/computeStats.test.ts
+++ b/src/data/stats/computeStats.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { computeStats } from './computeStats';
+import type { BaseStatValues, ResolvedStatModifier } from './types';
+
+const BASE: BaseStatValues = {
+  level: 60,
+  baseAtk: 1000,
+  baseHp: 1000,
+  weaponAtk: 0,
+  baseAttrs: { strength: 0, agility: 0, intellect: 0, will: 0 },
+  mainAttributeName: 'strength',
+  secondaryAttributeName: 'agility',
+};
+
+describe('computeStats — dynamic attributeAtkPercent', () => {
+  it('applies a dynamic (runtime) attributeAtkPercent buff to ATK', () => {
+    const without = computeStats(BASE, [], []);
+    const withBuff = computeStats(
+      BASE,
+      [],
+      [{ stat: { modifier: 'attributeAtkPercent' }, value: 10 } as unknown as ResolvedStatModifier],
+    );
+
+    // With zeroed base attributes the attribute bonus is exactly 1; a +10 attributeAtkPercent
+    // dynamic mod adds +0.10 to that multiplicative bonus (regression guard: this used to be dropped).
+    expect(without.attack).toBe(1000);
+    expect(withBuff.attack).toBe(1100);
+    expect(withBuff.attack).toBeGreaterThan(without.attack);
+  });
+});

--- a/src/data/stats/computeStats.ts
+++ b/src/data/stats/computeStats.ts
@@ -270,8 +270,7 @@ export function computeStats(
         atkPercent += pct;
         break;
       case 'attributeAtkPercent':
-        // Sheet effects are converted to per-attribute coefficients in Phase 2 (attrAtkCoeff) and
-        // skipped there; dynamic (runtime) mods arrive here pre-resolved and contribute directly.
+        // Dynamic (runtime) mods arrive pre-resolved here; sheet effects were converted in Phase 2.
         attrAtkBonusDelta += pct;
         break;
       case 'atkFlat':

--- a/src/data/stats/computeStats.ts
+++ b/src/data/stats/computeStats.ts
@@ -169,6 +169,7 @@ export function computeStats(
 
   let atkPercent = 0;
   let flatAtk = 0;
+  let attrAtkBonusDelta = 0;
   let hpPercent = 0;
   let flatHp = 0;
   let defPercent = 0;
@@ -269,7 +270,10 @@ export function computeStats(
         atkPercent += pct;
         break;
       case 'attributeAtkPercent':
-        break; // handled via attrAtkCoeff in Phase 2
+        // Sheet effects are converted to per-attribute coefficients in Phase 2 (attrAtkCoeff) and
+        // skipped there; dynamic (runtime) mods arrive here pre-resolved and contribute directly.
+        attrAtkBonusDelta += pct;
+        break;
       case 'atkFlat':
         flatAtk += val;
         break;
@@ -414,7 +418,8 @@ export function computeStats(
     attrAtkCoeff.strength * attrs.strength +
     attrAtkCoeff.agility * attrs.agility +
     attrAtkCoeff.intellect * attrs.intellect +
-    attrAtkCoeff.will * attrs.will;
+    attrAtkCoeff.will * attrs.will +
+    attrAtkBonusDelta;
   const baseAtkTotal = baseAtk + weaponAtk;
   const attack = Math.floor((baseAtkTotal * (1 + atkPercent) + flatAtk) * attributeBonus);
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -422,7 +422,7 @@
     }
   },
   "skillType": {
-    "attack": "Final Strike",
+    "attack": "Basic Attack",
     "dodge": "Dodge",
     "dive": "Dive Attack",
     "execution": "Finisher",

--- a/src/simulation/compiler/compileTimeline.finalStrike.test.ts
+++ b/src/simulation/compiler/compileTimeline.finalStrike.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { compileTimeline } from './compileTimeline';
+import type { Action, ActionNode, Hit } from './types';
+
+function hit(offset: number): Hit {
+  return { offset, spRecovery: 0, spReturn: 0, stagger: 0, multiplier: 100 };
+}
+
+function basicAttackNode(
+  id: string,
+  hits: Hit[],
+  seq?: { index: number; total: number },
+): ActionNode {
+  const node = {
+    instanceId: id,
+    id,
+    skillId: id,
+    type: 'basicAttack',
+    name: id,
+    logicalStartTime: 0,
+    element: 'physical',
+    enhancementTime: 0,
+    startTime: 0,
+    cooldown: 0,
+    spCost: 0,
+    gaugeCost: 0,
+    gaugeGain: 0,
+    teamGaugeGain: 0,
+    duration: 1,
+    triggerWindow: 0,
+    animationTime: 0,
+    hits,
+    ...(seq ? { sequenceIndex: seq.index, sequenceTotal: seq.total } : {}),
+  } as unknown as Action;
+  return { id, type: 'action', trackId: '', trackIndex: 0, node };
+}
+
+describe('compileTimeline — finalStrike auto-tagging', () => {
+  it('tags only the last hit of a completed basic-attack sequence as finalStrike', () => {
+    const result = compileTimeline([
+      basicAttackNode('A', [hit(0), hit(0.5)], { index: 3, total: 3 }),
+    ]);
+    const hits = result.actions[0]!.resolvedHits;
+    expect(hits[0]!.skillType).toBe('basicAttack');
+    expect(hits[1]!.skillType).toBe('finalStrike');
+  });
+
+  it('tags a single-hit basic attack (no sequence info) as finalStrike', () => {
+    const result = compileTimeline([basicAttackNode('A', [hit(0)])]);
+    expect(result.actions[0]!.resolvedHits[0]!.skillType).toBe('finalStrike');
+  });
+
+  it('does not tag finalStrike mid-sequence', () => {
+    const result = compileTimeline([
+      basicAttackNode('A', [hit(0), hit(0.5)], { index: 1, total: 3 }),
+    ]);
+    for (const h of result.actions[0]!.resolvedHits) {
+      expect(h.skillType).toBe('basicAttack');
+    }
+  });
+});

--- a/src/simulation/compiler/compileTimeline.ts
+++ b/src/simulation/compiler/compileTimeline.ts
@@ -159,9 +159,8 @@ function resolveAction(
     });
   });
 
-  // The last hit of a completed basic-attack sequence is tagged 'finalStrike' so finalStrike-scoped
-  // modifiers (e.g. last-rite, sundered-prince) match. Mirrors TriggerRegistry.onFinalStrike gating:
-  // sequenceIndex/sequenceTotal, with the attackSequence* fallback; sequenceTotal 0 = single hit.
+  // Tag the last hit of a completed basic-attack sequence 'finalStrike' (mirrors
+  // TriggerRegistry.onFinalStrike gating; sequenceTotal 0 = single hit).
   const seqNode = action as any;
   const sequenceIndex = Number(seqNode.sequenceIndex ?? seqNode.attackSequenceIndex) || 0;
   const sequenceTotal = Number(seqNode.sequenceTotal ?? seqNode.attackSequenceTotal) || 0;

--- a/src/simulation/compiler/compileTimeline.ts
+++ b/src/simulation/compiler/compileTimeline.ts
@@ -159,17 +159,28 @@ function resolveAction(
     });
   });
 
+  // The last hit of a completed basic-attack sequence is tagged 'finalStrike' so finalStrike-scoped
+  // modifiers (e.g. last-rite, sundered-prince) match. Mirrors TriggerRegistry.onFinalStrike gating:
+  // sequenceIndex/sequenceTotal, with the attackSequence* fallback; sequenceTotal 0 = single hit.
+  const seqNode = action as any;
+  const sequenceIndex = Number(seqNode.sequenceIndex ?? seqNode.attackSequenceIndex) || 0;
+  const sequenceTotal = Number(seqNode.sequenceTotal ?? seqNode.attackSequenceTotal) || 0;
+  const isFinalStrikeAction =
+    action.type === 'basicAttack' && (sequenceTotal === 0 || sequenceIndex === sequenceTotal);
+  const lastHitIndex = (action.hits?.length ?? 0) - 1;
+
   const resolvedHits: ResolvedHit[] = (action.hits || []).map((hit, hitIndex) => {
     const realTime = timeCtx.getShiftedEndTime(realStartTime, Number(hit.offset) || 0, item.id);
     const treatAsReaction = (hit as any).treatAsReaction as string | undefined;
     const treatAsSkillType = (hit as any).treatAsSkillType as string | undefined;
+    const isFinalHit = isFinalStrikeAction && hitIndex === lastHitIndex;
 
     return {
       ...hit,
       realTime,
       realOffset: realTime - realStartTime,
       time: timeCtx.toGameTime(realTime),
-      skillType: treatAsSkillType ?? action.type,
+      skillType: treatAsSkillType ?? (isFinalHit ? 'finalStrike' : action.type),
       skillId: (hit as any).skillId ?? action.skillId,
       element: hit.element || action.element,
       _actionInstanceId: item.id,

--- a/src/simulation/events/ActionEndHandler.ts
+++ b/src/simulation/events/ActionEndHandler.ts
@@ -37,11 +37,15 @@ export class ActionEndHandler implements EventHandler<ActionEndEvent> {
 
     const action = ctx.getAction(e.payload.actionId);
     if (action) {
-      // Scale down UE proportionally to returned SP consumed.
-      // Insufficient SP is ignored — only returned SP reduces UE gain.
-      const actualCost: number = (action as any)._actualSpCost ?? action.node.spCost ?? 0;
+      // Scale UE by the real SP actually paid, relative to the base cost the UE gain is calibrated
+      // against (node.UE = spCost/100 * 6.5). Both SP-cost reductions and returned SP shrink the
+      // real amount paid, so a reduced/free cast grants proportionally less UE. Insufficient SP is
+      // ignored. (_actualSpCost is the post-reduction cost the SP_CHANGE actually consumed.)
+      const baseCost: number = action.node.spCost ?? 0;
+      const finalSpCost: number = (action as any)._actualSpCost ?? baseCost;
       const returnedConsumed: number = (action as any)._returnedConsumed ?? 0;
-      const ueFraction = actualCost > 0 ? 1 - returnedConsumed / actualCost : 1;
+      const realPaid = finalSpCost - returnedConsumed;
+      const ueFraction = baseCost > 0 ? Math.min(1, Math.max(0, realPaid / baseCost)) : 1;
 
       const ueTime = e.time - 0.01;
       const battleSkillRecoveredConsumed = Number((action as any)._recoveredConsumed) || 0;

--- a/src/simulation/events/ActionEndHandler.ts
+++ b/src/simulation/events/ActionEndHandler.ts
@@ -37,10 +37,8 @@ export class ActionEndHandler implements EventHandler<ActionEndEvent> {
 
     const action = ctx.getAction(e.payload.actionId);
     if (action) {
-      // Scale UE by the real SP actually paid, relative to the base cost the UE gain is calibrated
-      // against (node.UE = spCost/100 * 6.5). Both SP-cost reductions and returned SP shrink the
-      // real amount paid, so a reduced/free cast grants proportionally less UE. Insufficient SP is
-      // ignored. (_actualSpCost is the post-reduction cost the SP_CHANGE actually consumed.)
+      // Scale UE by the SP actually paid vs the base cost it's calibrated against; SP-cost
+      // reductions and returned SP both shrink it. (_actualSpCost = post-reduction cost consumed.)
       const baseCost: number = action.node.spCost ?? 0;
       const finalSpCost: number = (action as any)._actualSpCost ?? baseCost;
       const returnedConsumed: number = (action as any)._returnedConsumed ?? 0;

--- a/src/simulation/events/ActionStartHandler.ts
+++ b/src/simulation/events/ActionStartHandler.ts
@@ -2,8 +2,9 @@ import type { EventHandler } from '@/simulation/events/EventHandler.ts';
 import type { ActionStartEvent } from '@/simulation/events/event.types.ts';
 import type { SimulationContext } from '@/simulation/engine/SimulationContext.ts';
 import type { TriggerRegistry } from '@/simulation/engine/TriggerRegistry';
-import type { OperatorEffectExpireEvent } from '@/simulation/engine/types';
+import type { OperatorEffectExpireEvent, SourceSlot } from '@/simulation/engine/types';
 import { resolveEffectiveActionSkillType } from '@/simulation/events/actionSkillType';
+import { pushSourceQueue, consumeSourceQueue } from '@/simulation/state/sourceQueue';
 
 export class ActionStartHandler implements EventHandler<ActionStartEvent> {
   private registry?: TriggerRegistry;
@@ -115,12 +116,16 @@ export class ActionStartHandler implements EventHandler<ActionStartEvent> {
       if (!action.consumedStacks) action.consumedStacks = {};
       action.consumedStacks.link = consumed;
 
-      // Stamp per-source link attribution for LMDI
-      const linkSourceMap: Record<string, number> = {};
+      // Stamp per-source link attribution for LMDI. Attribute only the actually-consumed stacks
+      // (FIFO, newest kept) via a source queue capped at `consumed`, rather than crediting every
+      // source its full stacks — so the breakdown sums to `consumed` even when total link stacks
+      // exceed the cap. (Ordering uses collection order as a proxy for application order, since
+      // Endaxis keeps per-source link entries rather than one pooled entry with a live sourceQueue.)
+      const sourceQueue: SourceSlot[] = [];
       for (const { sourceId, stacks } of deduped.values()) {
-        linkSourceMap[sourceId] = (linkSourceMap[sourceId] ?? 0) + stacks;
+        pushSourceQueue(sourceQueue, sourceId, stacks, consumed);
       }
-      action.consumedLinkSources = linkSourceMap;
+      action.consumedLinkSources = consumeSourceQueue(sourceQueue);
     }
 
     // Schedule consumption of each link entry at priority 3

--- a/src/simulation/events/ActionStartHandler.ts
+++ b/src/simulation/events/ActionStartHandler.ts
@@ -116,11 +116,8 @@ export class ActionStartHandler implements EventHandler<ActionStartEvent> {
       if (!action.consumedStacks) action.consumedStacks = {};
       action.consumedStacks.link = consumed;
 
-      // Stamp per-source link attribution for LMDI. Attribute only the actually-consumed stacks
-      // (FIFO, newest kept) via a source queue capped at `consumed`, rather than crediting every
-      // source its full stacks — so the breakdown sums to `consumed` even when total link stacks
-      // exceed the cap. (Ordering uses collection order as a proxy for application order, since
-      // Endaxis keeps per-source link entries rather than one pooled entry with a live sourceQueue.)
+      // Attribute only the actually-consumed link stacks per source (FIFO, newest kept) so the
+      // breakdown sums to `consumed` rather than over-crediting when total link exceeds the cap.
       const sourceQueue: SourceSlot[] = [];
       for (const { sourceId, stacks } of deduped.values()) {
         pushSourceQueue(sourceQueue, sourceId, stacks, consumed);

--- a/src/simulation/events/HitHandler.ts
+++ b/src/simulation/events/HitHandler.ts
@@ -185,9 +185,8 @@ export class HitHandler implements EventHandler<HitEvent> {
 
       const element = reactionMeta.element;
       const enemyResistance = getEnemyResistanceValue(ctx, element);
-      // Synthetic (treatAsReaction) hits still scale by the operator-level coefficient — a crush
-      // dealt via treatAsReaction levels exactly like a real crush. `synthetic` only suppresses the
-      // reaction marker / vulnerability consumption / reaction triggers, not the level coefficient.
+      // Synthetic (treatAsReaction) hits scale by the level coefficient too — synthetic only
+      // suppresses the reaction marker/vulnerability/triggers, not the coefficient.
       const levelCoeff = computeLevelCoefficient(
         operatorLevel,
         reactionMeta.reactionType as ReactionDamageType,

--- a/src/simulation/events/HitHandler.ts
+++ b/src/simulation/events/HitHandler.ts
@@ -167,7 +167,7 @@ export class HitHandler implements EventHandler<HitEvent> {
           external: entry.external,
         });
       }
-      const operatorStatus = computeStats(baseStats, [], dynamicMods);
+      const operatorStatus = computeStats(baseStats, [], dynamicMods, undefined, hit.skillId);
 
       const enemyEntries = [...ctx.state.enemy.enemyStatusEffects.values()].filter(
         entry => e.time < entry.expiresAt,
@@ -185,18 +185,22 @@ export class HitHandler implements EventHandler<HitEvent> {
 
       const element = reactionMeta.element;
       const enemyResistance = getEnemyResistanceValue(ctx, element);
-      const levelCoeff = reactionMeta.synthetic
-        ? 1
-        : computeLevelCoefficient(operatorLevel, reactionMeta.reactionType as ReactionDamageType);
+      // Synthetic (treatAsReaction) hits still scale by the operator-level coefficient — a crush
+      // dealt via treatAsReaction levels exactly like a real crush. `synthetic` only suppresses the
+      // reaction marker / vulnerability consumption / reaction triggers, not the level coefficient.
+      const levelCoeff = computeLevelCoefficient(
+        operatorLevel,
+        reactionMeta.reactionType as ReactionDamageType,
+      );
       const artsIntensityMult = computeArtsIntensityDamageMult(operatorStatus.artsIntensity);
       const effectivenessMult = reactionMeta.effectiveness ?? 1;
 
-      // No skill-type scoping for reaction damage
+      // No skill-type scoping for reaction damage, but skillId- and element-scoped mods still apply.
       const mods = filterDamageModifiers(
         operatorStatus.damageModifiers ?? [],
         element,
         undefined,
-        undefined,
+        hit.skillId,
       );
 
       const elementalSusc =

--- a/src/simulation/events/effectDispatch.dotTick.test.ts
+++ b/src/simulation/events/effectDispatch.dotTick.test.ts
@@ -31,9 +31,7 @@ describe('scheduleDotTicks', () => {
     const ticks = enqueued.filter(e => e.type === 'DOT_TICK');
     expect(ticks.length).toBeGreaterThan(0);
     for (const e of ticks) {
-      // A DoT tick must not inherit the source skill's skillType (regression guard)...
       expect(e.payload.skillType).toBeUndefined();
-      // ...but skillId scoping is still honored.
       expect(e.payload.skillId).toBe('skill1');
     }
   });

--- a/src/simulation/events/effectDispatch.dotTick.test.ts
+++ b/src/simulation/events/effectDispatch.dotTick.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { scheduleDotTicks } from './effectDispatch';
+import type { ResolvedDamageOverTimeEffect } from '@/data/types';
+import type { SimulationContext } from '@/simulation/engine/SimulationContext';
+
+describe('scheduleDotTicks', () => {
+  it('emits DOT_TICK ticks with no skillType but preserves skillId', () => {
+    const enqueued: Array<{ type: string; payload: Record<string, unknown> }> = [];
+    const ctx = {
+      getShiftedTime: (t: number, o: number) => t + o,
+      getAction: () => undefined,
+      consumedStacksWriteKeys: new Set<string>(),
+      queue: {
+        enqueue: (e: unknown) =>
+          enqueued.push(e as { type: string; payload: Record<string, unknown> }),
+        cancel: () => {},
+      },
+    } as unknown as SimulationContext;
+
+    const r = {
+      kind: 'damageOverTime',
+      id: 'burn',
+      multiplier: 100,
+      interval: 1,
+      duration: 2,
+      element: 'heat',
+    } as unknown as ResolvedDamageOverTimeEffect;
+
+    scheduleDotTicks(r, 0, 'track1', ctx, 'action1', 'skill1');
+
+    const ticks = enqueued.filter(e => e.type === 'DOT_TICK');
+    expect(ticks.length).toBeGreaterThan(0);
+    for (const e of ticks) {
+      // A DoT tick must not inherit the source skill's skillType (regression guard)...
+      expect(e.payload.skillType).toBeUndefined();
+      // ...but skillId scoping is still honored.
+      expect(e.payload.skillId).toBe('skill1');
+    }
+  });
+});

--- a/src/simulation/events/effectDispatch.ts
+++ b/src/simulation/events/effectDispatch.ts
@@ -963,9 +963,8 @@ export function scheduleDotTicks(
           effectId,
           element: r.element,
           multiplier: tickMultiplier,
-          // A DoT tick is its own damage instance, not a skill hit — it must NOT inherit the source
-          // skill's type, so skill-type-scoped modifiers (dmgBonus/directMultiplier/attack% and the
-          // link multiplier) don't apply. Mirrors reaction damage; skillId/element scoping is kept.
+          // A DoT tick must not inherit the source skill's skillType (skill-type-scoped mods + link
+          // would wrongly apply); skillId/element scoping is kept, mirroring reaction damage.
           skillType: undefined,
           skillId: sourceSkillId,
           canCrit: r.canCrit,

--- a/src/simulation/events/effectDispatch.ts
+++ b/src/simulation/events/effectDispatch.ts
@@ -899,7 +899,6 @@ export function scheduleDotTicks(
   time: number,
   sourceTrackId: string,
   ctx: SimulationContext,
-  sourceSkillType?: string,
   sourceActionId?: string,
   sourceSkillId?: string,
 ): void {
@@ -964,7 +963,10 @@ export function scheduleDotTicks(
           effectId,
           element: r.element,
           multiplier: tickMultiplier,
-          skillType: sourceSkillType,
+          // A DoT tick is its own damage instance, not a skill hit — it must NOT inherit the source
+          // skill's type, so skill-type-scoped modifiers (dmgBonus/directMultiplier/attack% and the
+          // link multiplier) don't apply. Mirrors reaction damage; skillId/element scoping is kept.
+          skillType: undefined,
           skillId: sourceSkillId,
           canCrit: r.canCrit,
           consumedStacks,
@@ -1250,7 +1252,6 @@ export function dispatchSingleActorEffect(
       time,
       sourceTrackId,
       ctx,
-      skillType,
       actionId,
       skillId,
     );

--- a/src/simulation/state/TeamState.test.ts
+++ b/src/simulation/state/TeamState.test.ts
@@ -25,4 +25,27 @@ describe('TeamState', () => {
     expect(team.getRefundSp()).toBe(0);
     expect(team.getRecoverSp()).toBe(0);
   });
+
+  it('displaces refund SP into recover while regenerating at cap', () => {
+    const team = new TeamState(
+      {
+        maxSp: 100,
+        initialSp: 0,
+        spRegenRate: 10,
+        skillSpCostDefault: 100,
+        linkCdReduction: 0,
+        prepDuration: 0,
+      },
+      {} as never,
+    );
+
+    team.addSp(40, 'recover');
+    team.addSp(60, 'refund'); // at cap: 40 recover + 60 refund = 100
+
+    team.advanceTime(10, 5); // 100 SP of regen into recover; overflow displaces refund first
+
+    expect(team.getSp()).toBe(100);
+    expect(team.getRefundSp()).toBe(0);
+    expect(team.getRecoverSp()).toBe(100);
+  });
 });

--- a/src/simulation/state/TeamState.test.ts
+++ b/src/simulation/state/TeamState.test.ts
@@ -40,9 +40,9 @@ describe('TeamState', () => {
     );
 
     team.addSp(40, 'recover');
-    team.addSp(60, 'refund'); // at cap: 40 recover + 60 refund = 100
+    team.addSp(60, 'refund');
 
-    team.advanceTime(10, 5); // 100 SP of regen into recover; overflow displaces refund first
+    team.advanceTime(10, 5);
 
     expect(team.getSp()).toBe(100);
     expect(team.getRefundSp()).toBe(0);

--- a/src/simulation/state/TeamState.ts
+++ b/src/simulation/state/TeamState.ts
@@ -151,7 +151,10 @@ export class TeamState implements BaseGameState<TeamSnapshot> {
   }
 
   private regenSp(dt: number) {
-    if (this.getSp() >= this.config.maxSp) {
+    // Keep regen running while below cap (room to grow / repay debt) OR there is refund SP left to
+    // displace. Natural regen goes to the recover pool and trimOverflow('recover') then reduces
+    // refund SP first, converting refund → recover so a later spend draws recover SP (grants UE).
+    if (this.recoverSp >= this.config.maxSp && this.refundSp <= 0) {
       return;
     }
 
@@ -168,10 +171,8 @@ export class TeamState implements BaseGameState<TeamSnapshot> {
       this.spRegenPauseDuration = 0;
     }
 
-    if (this.getSp() < this.config.maxSp) {
-      const gain = effectiveDuration * this.config.spRegenRate;
-      this.addSp(gain, 'recover');
-    }
+    const gain = effectiveDuration * this.config.spRegenRate;
+    this.addSp(gain, 'recover');
   }
 
   private getPositiveSp() {

--- a/src/simulation/state/TeamState.ts
+++ b/src/simulation/state/TeamState.ts
@@ -151,9 +151,8 @@ export class TeamState implements BaseGameState<TeamSnapshot> {
   }
 
   private regenSp(dt: number) {
-    // Keep regen running while below cap (room to grow / repay debt) OR there is refund SP left to
-    // displace. Natural regen goes to the recover pool and trimOverflow('recover') then reduces
-    // refund SP first, converting refund → recover so a later spend draws recover SP (grants UE).
+    // Keep regen running while refund SP remains to displace: regen adds to recover and
+    // trimOverflow('recover') converts refund → recover (so a later spend draws recover SP → UE).
     if (this.recoverSp >= this.config.maxSp && this.refundSp <= 0) {
       return;
     }

--- a/src/simulation/state/sourceQueue.test.ts
+++ b/src/simulation/state/sourceQueue.test.ts
@@ -13,7 +13,7 @@ describe('sourceQueue', () => {
   it('trims oldest first when total exceeds the cap (keeps newest stacks)', () => {
     const q: SourceSlot[] = [];
     pushSourceQueue(q, 'A', 2, 4);
-    pushSourceQueue(q, 'B', 3, 4); // total 5 > 4 -> drop oldest A by 1
+    pushSourceQueue(q, 'B', 3, 4);
     expect(consumeSourceQueue(q)).toEqual({ A: 1, B: 3 });
   });
 

--- a/src/simulation/state/sourceQueue.test.ts
+++ b/src/simulation/state/sourceQueue.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { pushSourceQueue, consumeSourceQueue } from './sourceQueue';
+import type { SourceSlot } from '@/simulation/engine/types';
+
+describe('sourceQueue', () => {
+  it('keeps every stack and attributes per source when under the cap', () => {
+    const q: SourceSlot[] = [];
+    pushSourceQueue(q, 'A', 2, 4);
+    pushSourceQueue(q, 'B', 1, 4);
+    expect(consumeSourceQueue(q)).toEqual({ A: 2, B: 1 });
+  });
+
+  it('trims oldest first when total exceeds the cap (keeps newest stacks)', () => {
+    const q: SourceSlot[] = [];
+    pushSourceQueue(q, 'A', 2, 4);
+    pushSourceQueue(q, 'B', 3, 4); // total 5 > 4 -> drop oldest A by 1
+    expect(consumeSourceQueue(q)).toEqual({ A: 1, B: 3 });
+  });
+
+  it('merges consecutive stacks from the same source', () => {
+    const q: SourceSlot[] = [];
+    pushSourceQueue(q, 'A', 1, 10);
+    pushSourceQueue(q, 'A', 2, 10);
+    expect(q).toHaveLength(1);
+    expect(consumeSourceQueue(q)).toEqual({ A: 3 });
+  });
+});

--- a/src/simulation/state/sourceQueue.ts
+++ b/src/simulation/state/sourceQueue.ts
@@ -1,8 +1,7 @@
 import type { SourceSlot } from '@/simulation/engine/types';
 
 // ─── FIFO source queue helpers ──────────────────────────────────────────────
-// Retain a per-source breakdown while stacks accumulate from multiple appliers
-// (capped, oldest trimmed first) so the consumed stacks can be attributed for LMDI.
+// Retain a per-source breakdown as stacks accumulate (oldest trimmed first) for LMDI attribution.
 
 /** Push stacks to a FIFO source queue, capping total at maxStacks by trimming oldest first. */
 export function pushSourceQueue(

--- a/src/simulation/state/sourceQueue.ts
+++ b/src/simulation/state/sourceQueue.ts
@@ -1,0 +1,42 @@
+import type { SourceSlot } from '@/simulation/engine/types';
+
+// ─── FIFO source queue helpers ──────────────────────────────────────────────
+// Retain a per-source breakdown while stacks accumulate from multiple appliers
+// (capped, oldest trimmed first) so the consumed stacks can be attributed for LMDI.
+
+/** Push stacks to a FIFO source queue, capping total at maxStacks by trimming oldest first. */
+export function pushSourceQueue(
+  queue: SourceSlot[],
+  sourceId: string,
+  count: number,
+  maxStacks: number,
+): void {
+  const last = queue[queue.length - 1];
+  if (last && last.sourceId === sourceId) {
+    last.count += count;
+  } else {
+    queue.push({ sourceId, count });
+  }
+  let total = queue.reduce((s, slot) => s + slot.count, 0);
+  while (total > maxStacks && queue.length > 0) {
+    const oldest = queue[0];
+    if (!oldest) break;
+    const excess = total - maxStacks;
+    if (oldest.count <= excess) {
+      total -= oldest.count;
+      queue.shift();
+    } else {
+      oldest.count -= excess;
+      total = maxStacks;
+    }
+  }
+}
+
+/** Flatten a source queue into a sourceId → stacks map. */
+export function consumeSourceQueue(queue: SourceSlot[]): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const slot of queue) {
+    result[slot.sourceId] = (result[slot.sourceId] ?? 0) + slot.count;
+  }
+  return result;
+}

--- a/src/stores/timelineStore.test.ts
+++ b/src/stores/timelineStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { useTimelineStore } from './timelineStore';
+import { setLocale } from '@/i18n';
 
 describe('timeline skill library editing', () => {
   beforeEach(() => {
@@ -75,6 +76,10 @@ describe('timeline skill library editing', () => {
   });
 
   it('names generic basic attacks as 普攻 and only the final segment as 重击', async () => {
+    // The basic-attack group name is localized (skillType.attack) and the final segment is the
+    // hardcoded 重击, so this test asserts the app's default zh-CN naming; pin the locale since the
+    // test env otherwise detects the host language.
+    setLocale('zh-CN');
     const store = useTimelineStore();
     await store.fetchGameData();
 

--- a/src/stores/timelineStore.test.ts
+++ b/src/stores/timelineStore.test.ts
@@ -76,9 +76,6 @@ describe('timeline skill library editing', () => {
   });
 
   it('names generic basic attacks as 普攻 and only the final segment as 重击', async () => {
-    // The basic-attack group name is localized (skillType.attack) and the final segment is the
-    // hardcoded 重击, so this test asserts the app's default zh-CN naming; pin the locale since the
-    // test env otherwise detects the host language.
     setLocale('zh-CN');
     const store = useTimelineStore();
     await store.fetchGameData();


### PR DESCRIPTION
Compared the Endaxis engine file-to-file against the optimizer (`simulation/` + `data/stats/*`, `collect.ts`, `effectPresets.ts`, `team-status.ts`) and fixed shared logic that had silently diverged, keeping all intentional Endaxis features.

逐文件对比了 Endaxis 与 optimizer 的模拟引擎，修复了共享逻辑中悄悄产生偏差的部分，同时保留了 Endaxis 所有有意为之的功能。

### Ported optimizer bugfixes / 移植 optimizer 的修复
- **UE on partial SP cost** — reduced/free casts no longer grant full ult energy. / SP 消耗被减免时不再给满充能。
- **Reaction level coeff (mifu)** — `treatAsReaction` hits now scale by the level coefficient. / `treatAsReaction` 命中现在按等级系数缩放。
- **Reaction skillId scoping (mifu t1)** — reaction damage now honors skillId-scoped mods. / 反应伤害现在生效 skillId 作用域的加成。
- **Dynamic `attributeAtkPercent` (camille)** — runtime ATK buffs (e.g. lifeng-t1) were silently dropped; now applied. / 运行时的攻击力 buff（如 lifeng-t1）之前被丢弃，现已生效。
- **DoT-tick skillType (fix sharing)** — DoT ticks no longer inherit skill-type-scoped mods / link. / 持续伤害的每跳不再继承技能类型作用域的加成与连携。

### Endaxis regression fixed / 修复 Endaxis 的回归
- **`finalStrike` auto-tag** — restored on the last basic-attack-sequence hit, so `finalStrike`-scoped mods (last-rite, sundered-prince) apply again. / 恢复普攻序列最后一击的 `finalStrike` 标记，相关加成重新生效。

### Adjudicated items / 经讨论后处理
- **TeamState** — displace refund→recover SP at cap (a later spend then grants UE). / 满 SP 时把返还 SP 转为恢复 SP，之后消耗可产生充能。
- **Link attribution** — restore FIFO per-source attribution so `consumedLinkSources` sums to the consumed amount (damage unchanged). / 恢复 FIFO 按来源归因，连携归因数与实际消耗一致（伤害不变）。
- **en label** — `skillType.attack` `"Final Strike"` → `"Basic Attack"`. / 修正英文文案。

### Tests / 测试
Added unit tests for the testable fixes; pinned the basic-attack naming test to zh-CN. `type-check` clean, `vitest` **320/320** (the previously-failing `普攻` test is fixed). / 为可测的修复补充了单测；命名测试锁定 zh-CN。类型检查通过，测试 320/320（原先失败的 `普攻` 测试已修复）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)