### PR TITLE
Feat : 新增干员特定技能的前置条件检查，修复诀终结技期间充能问题

### DIFF
--- a/src/components/ActionItem.vue
+++ b/src/components/ActionItem.vue
@@ -14,7 +14,7 @@ const emit = defineEmits(['hit-click']);
 
 const store = useTimelineStore();
 const connectionHandler = useDragConnection();
-const { t } = useI18n({ useScope: 'global' });
+const { t, te } = useI18n({ useScope: 'global' });
 const TYPE_SHORTHAND = {
   basicAttack: 'A',
   dive: 'D',
@@ -197,6 +197,12 @@ const requisiteTitle = computed(() => {
       need: fmt(w.need ?? 0),
       current: fmt(w.current ?? 0),
     });
+  if (w.kind === 'skillRequisite') {
+    if (w.messageKey && te(w.messageKey)) {
+      return t(w.messageKey, w.params || {});
+    }
+    return t('actionItem.requisiteTitle.skillRequisiteFallback');
+  }
   return '';
 });
 

--- a/src/data/enums.ts
+++ b/src/data/enums.ts
@@ -112,6 +112,7 @@ export const EFFECT_CONDITION_KINDS = Object.freeze([
   'operatorStatus',
   'operatorHp',
   'comboNotOnCooldown',
+  'ultimateEnhancement',
   'actionLinkConsumed',
   'not',
   'or',

--- a/src/data/operators/arcane.ts
+++ b/src/data/operators/arcane.ts
@@ -1,5 +1,5 @@
 import { map, range } from 'lodash';
-import type { OperatorSheet, ArtsElement, TriggerEffect, Effect } from '../types';
+import type { OperatorSheet, ArtsElement, TriggerEffect, Effect, SkillRequisite } from '../types';
 
 const INFLICTIONS: ArtsElement[] = ['cryo', 'electric', 'nature', 'heat'];
 const INFLICTION_STATUSES = INFLICTIONS.map(x => `${x}Infliction`);
@@ -39,6 +39,18 @@ const COMBO_SKILL_EFFECTS: Effect[] = INFLICTIONS.map(x => ({
     consume: true,
   },
 }));
+
+const ULTIMATE_ARCANA_REQUISITE: SkillRequisite = {
+  id: 'arcane-ultimate-arcana-ready',
+  condition: {
+    kind: 'or',
+    conditions: [
+      { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+      { kind: 'operatorStatus', status: 'arcane-gloompurge-arcana-ready' },
+    ],
+  },
+  messageKey: 'actionItem.requisiteTitle.arcaneUltimateArcanaRequired',
+};
 
 const sheet: OperatorSheet = {
   new: true,
@@ -453,6 +465,7 @@ const sheet: OperatorSheet = {
             ],
           },
           ultimate: {
+            requisites: [ULTIMATE_ARCANA_REQUISITE],
             segments: [
               {
                 duration: 2.417,
@@ -861,6 +874,7 @@ const sheet: OperatorSheet = {
             ],
           },
           ultimate: {
+            requisites: [ULTIMATE_ARCANA_REQUISITE],
             segments: [
               {
                 duration: 2.417,

--- a/src/data/operators/laevatain.ts
+++ b/src/data/operators/laevatain.ts
@@ -1,4 +1,4 @@
-import type { Effect, OperatorSheet, StatusEffect } from '../types';
+import type { Effect, OperatorSheet, SkillRequisite, StatusEffect } from '../types';
 
 const GAIN_MELTING_FLAME_EFFECT: StatusEffect = {
   id: 'laevatain-melting-flame',
@@ -13,6 +13,24 @@ const GAIN_MELTING_FLAME_EFFECT: StatusEffect = {
     '/operators/laevatain/magma_3.webp',
     '/operators/laevatain/magma_4.webp',
   ],
+};
+
+const DURING_ULTIMATE_REQUISITE: SkillRequisite = {
+  id: 'laevatain-ultimate-enhancement',
+  condition: { kind: 'ultimateEnhancement' },
+  messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+};
+
+const OUTSIDE_ULTIMATE_BASIC_REQUISITE: SkillRequisite = {
+  id: 'laevatain-basic-outside-ultimate-enhancement',
+  condition: { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+};
+
+const OUTSIDE_ULTIMATE_BATTLE_REQUISITE: SkillRequisite = {
+  id: 'laevatain-battle-outside-ultimate-enhancement',
+  condition: { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBattleDuringUltimate',
 };
 
 const createAbsorbHeatInflictionEffects = (): Effect[] =>
@@ -185,6 +203,7 @@ const sheet: OperatorSheet = {
   ],
   combatSkills: {
     basicAttack: {
+      requisites: [OUTSIDE_ULTIMATE_BASIC_REQUISITE],
       segments: [
         {
           duration: 0.367,
@@ -278,6 +297,7 @@ const sheet: OperatorSheet = {
       ],
     },
     battleSkill: {
+      requisites: [OUTSIDE_ULTIMATE_BATTLE_REQUISITE],
       segments: [
         {
           duration: 1.73,
@@ -364,6 +384,7 @@ const sheet: OperatorSheet = {
           group: 'battleSkill',
           name: 'enhancedBattleSkill',
           icon: '/operators/laevatain/ultimate_skill.webp',
+          requisites: [DURING_ULTIMATE_REQUISITE],
           segments: [
             {
               duration: 1.1,
@@ -505,6 +526,7 @@ const sheet: OperatorSheet = {
           id: 'laevatain-basic-attack-during-ultimate',
           group: 'basicAttack',
           name: 'enhancedBasicAttack',
+          requisites: [DURING_ULTIMATE_REQUISITE],
           segments: [
             {
               duration: 0.6,

--- a/src/data/operators/yvonne.ts
+++ b/src/data/operators/yvonne.ts
@@ -1,4 +1,16 @@
-import type { OperatorSheet, Effect } from '../types';
+import type { OperatorSheet, Effect, SkillRequisite } from '../types';
+
+const DURING_ULTIMATE_REQUISITE: SkillRequisite = {
+  id: 'yvonne-ultimate-enhancement',
+  condition: { kind: 'ultimateEnhancement' },
+  messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+};
+
+const OUTSIDE_ULTIMATE_BASIC_REQUISITE: SkillRequisite = {
+  id: 'yvonne-basic-outside-ultimate-enhancement',
+  condition: { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+};
 
 const ENHANCED_BASIC_ATTACK_MULTIPLIER = [
   8.9, 9.8, 10.7, 11.6, 12.5, 13.4, 14.3, 15.1, 16, 17.2, 18.5, 20,
@@ -194,6 +206,7 @@ const sheet: OperatorSheet = {
   ],
   combatSkills: {
     basicAttack: {
+      requisites: [OUTSIDE_ULTIMATE_BASIC_REQUISITE],
       segments: [
         {
           duration: 0.567,
@@ -431,6 +444,7 @@ const sheet: OperatorSheet = {
         {
           group: 'basicAttack',
           name: 'enhancedBasicAttack',
+          requisites: [DURING_ULTIMATE_REQUISITE],
           segments: [
             {
               duration: 7.25,

--- a/src/data/operators/zhuang-fangyi.ts
+++ b/src/data/operators/zhuang-fangyi.ts
@@ -1,4 +1,28 @@
-import type { OperatorSheet, HitGroup, Effect } from '../types';
+import type { OperatorSheet, HitGroup, Effect, SkillRequisite } from '../types';
+
+const DURING_ULTIMATE_REQUISITE: SkillRequisite = {
+  id: 'zhuang-fangyi-ultimate-enhancement',
+  condition: { kind: 'ultimateEnhancement' },
+  messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+};
+
+const OUTSIDE_ULTIMATE_BASIC_REQUISITE: SkillRequisite = {
+  id: 'zhuang-fangyi-basic-outside-ultimate-enhancement',
+  condition: { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+};
+
+const OUTSIDE_ULTIMATE_BATTLE_REQUISITE: SkillRequisite = {
+  id: 'zhuang-fangyi-battle-outside-ultimate-enhancement',
+  condition: { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBattleDuringUltimate',
+};
+
+const OUTSIDE_ULTIMATE_COMBO_REQUISITE: SkillRequisite = {
+  id: 'zhuang-fangyi-combo-outside-ultimate-enhancement',
+  condition: { kind: 'not', condition: { kind: 'ultimateEnhancement' } },
+  messageKey: 'actionItem.requisiteTitle.enhancedComboDuringUltimate',
+};
 
 const BATTLE_FIRST_HIT_EFFECTS: Effect[] = [
   {
@@ -503,6 +527,7 @@ const sheet: OperatorSheet = {
   ],
   combatSkills: {
     basicAttack: {
+      requisites: [OUTSIDE_ULTIMATE_BASIC_REQUISITE],
       segments: [
         {
           duration: 0.5,
@@ -590,6 +615,7 @@ const sheet: OperatorSheet = {
       ],
     },
     battleSkill: {
+      requisites: [OUTSIDE_ULTIMATE_BATTLE_REQUISITE],
       segments: [
         {
           duration: 0.7,
@@ -611,6 +637,7 @@ const sheet: OperatorSheet = {
         {
           group: 'battleSkill',
           name: 'enhancedBattleSkill',
+          requisites: [DURING_ULTIMATE_REQUISITE],
           segments: [
             {
               duration: 0.7,
@@ -632,6 +659,7 @@ const sheet: OperatorSheet = {
       ],
     },
     comboSkill: {
+      requisites: [OUTSIDE_ULTIMATE_COMBO_REQUISITE],
       comboWindow: {
         triggers: [
           {
@@ -710,6 +738,7 @@ const sheet: OperatorSheet = {
         {
           group: 'comboSkill',
           name: 'enhancedComboSkill',
+          requisites: [DURING_ULTIMATE_REQUISITE],
           segments: [
             {
               duration: 1.2,
@@ -790,6 +819,7 @@ const sheet: OperatorSheet = {
         {
           group: 'basicAttack',
           name: 'enhancedBasicAttack',
+          requisites: [DURING_ULTIMATE_REQUISITE],
           segments: [
             {
               duration: 0.73,

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -244,7 +244,7 @@ export interface OperatorHpCondition {
 
 export interface NegatedCondition {
   kind: 'not';
-  condition: EnemyCondition | OperatorCondition | EnemyStaggeredCondition | OrCondition;
+  condition: EffectCondition;
 }
 
 export interface OrCondition {
@@ -264,6 +264,11 @@ export interface OperatorComboCdCondition {
   kind: 'comboNotOnCooldown';
 }
 
+/** True while the source operator is inside its own ultimate enhancement window. */
+export interface UltimateEnhancementCondition {
+  kind: 'ultimateEnhancement';
+}
+
 export type EffectCondition =
   | EnemyCondition
   | EnemyHpCondition
@@ -271,9 +276,19 @@ export type EffectCondition =
   | OperatorCondition
   | OperatorHpCondition
   | OperatorComboCdCondition
+  | UltimateEnhancementCondition
   | ActionLinkConsumedCondition
   | NegatedCondition
   | OrCondition;
+
+/** A prerequisite that must be satisfied before a skill/action can be released. */
+export interface SkillRequisite {
+  /** Stable id used by tests, diagnostics, and UI/i18n lookup. */
+  id: string;
+  condition: EffectCondition | EffectCondition[];
+  messageKey?: string;
+  params?: Record<string, unknown>;
+}
 
 // ─── Leveled value type ──────────────────────────────────────────────────────
 
@@ -890,6 +905,8 @@ export interface CombatSkillEntry {
     }[];
     duration: number;
   };
+  /** Release-time prerequisites shared by this skill and its segments. */
+  requisites?: SkillRequisite[];
 }
 
 /**
@@ -961,6 +978,8 @@ export interface SubSkillEntry {
   effects?: Effect[];
   icon?: string;
   cooldown?: Leveled<number>;
+  /** Release-time prerequisites shared by this sub-skill and its segments. */
+  requisites?: SkillRequisite[];
 }
 
 /** Picks the active form from resolved (equipment + general-form) attributes. */
@@ -1147,6 +1166,8 @@ export interface Segment {
   /** Per-segment SP cost for multi-stage battle skills. */
   spCost?: number;
   damageGroups: (HitGroup | TickGroup)[];
+  /** Release-time prerequisites that only apply to this segment. */
+  requisites?: SkillRequisite[];
 }
 
 export interface SystemConstants {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -50,6 +50,7 @@
     "dirtyHint": "Updated",
     "types": {
       "ACTION_START": "Action start",
+      "ACTION_REQUISITE_FAILED": "Release prerequisite",
       "ACTION_END": "Action end",
       "DAMAGE_HIT": "Damage",
       "CD_REDUCTION": "CD reduction",
@@ -1147,7 +1148,13 @@
       "comboWindow": "Not in combo window",
       "comboOrder": "Wrong combo skill order. Release {operator}'s combo skill first",
       "spInsufficient": "Insufficient SP, need {need}, current {current}",
-      "gaugeInsufficient": "Insufficient gauge, need {need}, current {current}"
+      "gaugeInsufficient": "Insufficient gauge, need {need}, current {current}",
+      "skillRequisiteFallback": "Skill release prerequisite is not met",
+      "ultimateEnhancementOnly": "Can only be released during the ultimate duration",
+      "enhancedBasicDuringUltimate": "Use enhanced basic attacks during the ultimate duration",
+      "enhancedBattleDuringUltimate": "Use enhanced battle skills during the ultimate duration",
+      "enhancedComboDuringUltimate": "Use enhanced combo skills during the ultimate duration",
+      "arcaneUltimateArcanaRequired": "Cannot release ultimate. Perform two heavy attacks or finishers first"
     }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -50,6 +50,7 @@
     "dirtyHint": "Обновлено",
     "types": {
       "ACTION_START": "Начало действия",
+      "ACTION_REQUISITE_FAILED": "Условие навыка",
       "ACTION_END": "Конец действия",
       "DAMAGE_HIT": "Урон",
       "CD_REDUCTION": "Снижение КД",
@@ -1030,7 +1031,13 @@
       "comboWindow": "Вне окна комбо",
       "comboOrder": "Неверный порядок комбо: сначала используйте комбо {operator}",
       "spInsufficient": "Недостаточно SP, нужно {need}, сейчас {current}",
-      "gaugeInsufficient": "Недостаточно шкалы, нужно {need}, сейчас {current}"
+      "gaugeInsufficient": "Недостаточно шкалы, нужно {need}, сейчас {current}",
+      "skillRequisiteFallback": "Условие активации навыка не выполнено",
+      "ultimateEnhancementOnly": "Можно использовать только во время действия ультимейта",
+      "enhancedBasicDuringUltimate": "Во время действия ультимейта используйте усиленные базовые атаки",
+      "enhancedBattleDuringUltimate": "Во время действия ультимейта используйте усиленные боевые навыки",
+      "enhancedComboDuringUltimate": "Во время действия ультимейта используйте усиленные комбо-навыки",
+      "arcaneUltimateArcanaRequired": "Нельзя использовать ультимейт: сначала выполните две тяжелые атаки или добивания"
     }
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -50,6 +50,7 @@
     "dirtyHint": "有更新",
     "types": {
       "ACTION_START": "动作开始",
+      "ACTION_REQUISITE_FAILED": "释放条件",
       "ACTION_END": "动作结束",
       "DAMAGE_HIT": "伤害",
       "CD_REDUCTION": "冷却缩减",
@@ -1147,7 +1148,13 @@
       "comboWindow": "不在连携窗口内",
       "comboOrder": "连携技释放顺序错误，需先释放{operator}的连携技",
       "spInsufficient": "技力不足，需要{need}，当前{current}",
-      "gaugeInsufficient": "终结技能量不足，需要{need}，当前{current}"
+      "gaugeInsufficient": "终结技能量不足，需要{need}，当前{current}",
+      "skillRequisiteFallback": "技能释放条件不满足",
+      "ultimateEnhancementOnly": "只能在终结技持续期间释放",
+      "enhancedBasicDuringUltimate": "终结技持续期间应释放强化普攻",
+      "enhancedBattleDuringUltimate": "终结技持续期间应释放强化战技",
+      "enhancedComboDuringUltimate": "终结技持续期间应释放强化连携",
+      "arcaneUltimateArcanaRequired": "无法释放终结技，需进行两次重击或处决"
     }
   }
 }

--- a/src/simulation/battleLogTypePresets.ts
+++ b/src/simulation/battleLogTypePresets.ts
@@ -10,6 +10,7 @@ const DAMAGE_TYPES = Object.freeze([
   'ULT_ENERGY_CHANGE',
   'CD_REDUCTION',
   'ACTION_START',
+  'ACTION_REQUISITE_FAILED',
   'ACTION_END',
 ]);
 

--- a/src/simulation/compiler/types.ts
+++ b/src/simulation/compiler/types.ts
@@ -1,7 +1,13 @@
 import type { ActorSnapshot, EnemyConfig, TeamConfig } from '@/simulation/state/types.ts';
 import type { OperatorStatus, ComputedEnemyStatus } from '@/types';
 import type { TimeContext } from '@/simulation/compiler/timeContext.ts';
-import type { Effect, EffectCondition, OperatorStat, ResolvedScalingDef } from '@/data/types';
+import type {
+  Effect,
+  EffectCondition,
+  OperatorStat,
+  ResolvedScalingDef,
+  SkillRequisite,
+} from '@/data/types';
 import type { DamageBreakdown } from '@/data/stats/computeDamage';
 import type { BaseStatValues } from '@/data/stats/types';
 
@@ -223,6 +229,10 @@ export interface Action {
   instanceId: string;
   type: ActionType;
   skillId: string;
+  skillKey?: string;
+  sourceSkillKey?: string;
+  segmentIndex?: number;
+  attackSegmentIndex?: number;
   name: string;
   startTime: number;
   logicalStartTime: number;
@@ -254,6 +264,7 @@ export interface Action {
   sourceWeaponId?: string | null;
   hits: Hit[];
   effects?: CompiledEffect[];
+  requisites?: SkillRequisite[];
 
   isLocked?: boolean;
   customBars?: any[];

--- a/src/simulation/engine/SimulationContext.ts
+++ b/src/simulation/engine/SimulationContext.ts
@@ -41,6 +41,8 @@ export interface SimulationContext {
   consumedStacksWriteKeys: Set<string>;
   /** Compute the real-time end point of a duration starting at startTime, accounting for any time freezes within the window. */
   getShiftedTime(startTime: number, duration: number): number;
+  /** Whether the actor is currently inside its own ultimate enhancement window. */
+  isUltimateEnhancementActive: (actorId: string, time: number) => boolean;
   isUltimateEnergyBlocked(actorId: string, time: number): boolean;
   /** Base stat values per track for damage calculation (baseAtk, weaponAtk, attrs, etc.). */
   getBaseStats: (trackId: string) => BaseStatValues | undefined;

--- a/src/simulation/engine/SimulationEngine.ts
+++ b/src/simulation/engine/SimulationEngine.ts
@@ -284,6 +284,11 @@ export class SimulationEngine {
     return map;
   }
 
+  isUltimateEnhancementActive(actorId: string, time: number) {
+    // TODO 函数的语义需要整理一下
+    return this.isUltimateEnergyBlocked(actorId, time);
+  }
+
   isUltimateEnergyBlocked(actorId: string, time: number) {
     const t = Number(time) || 0;
     const epsilon = 0.0001;
@@ -354,6 +359,7 @@ export class SimulationEngine {
       elementByTrackId: new Map(this.actors.map(a => [a.id, a.element])),
       consumedStacksWriteKeys: this.consumedStacksWriteKeys,
       getShiftedTime: this.getShiftedTime.bind(this),
+      isUltimateEnhancementActive: this.isUltimateEnhancementActive.bind(this),
       isUltimateEnergyBlocked: this.isUltimateEnergyBlocked.bind(this),
       getAllActions: () => this.timeline.actions,
       getBaseStats: (trackId: string) => this.baseStatsByTrack.get(trackId),

--- a/src/simulation/events/ActionStartHandler.ts
+++ b/src/simulation/events/ActionStartHandler.ts
@@ -5,6 +5,7 @@ import type { TriggerRegistry } from '@/simulation/engine/TriggerRegistry';
 import type { OperatorEffectExpireEvent, SourceSlot } from '@/simulation/engine/types';
 import { resolveEffectiveActionSkillType } from '@/simulation/events/actionSkillType';
 import { pushSourceQueue, consumeSourceQueue } from '@/simulation/state/sourceQueue';
+import { evaluateSkillRequisites } from '@/simulation/requisites/evaluateSkillRequisites';
 
 export class ActionStartHandler implements EventHandler<ActionStartEvent> {
   private registry?: TriggerRegistry;
@@ -24,6 +25,7 @@ export class ActionStartHandler implements EventHandler<ActionStartEvent> {
         spCost: isPrepAction ? 0 : e.payload.spCost,
       },
     });
+    this.logRequisiteFailures(e, ctx);
     const spFreezeDuration = isPrepAction ? 0 : this.getSpFreezeDuration(e);
     if (spFreezeDuration > 0) {
       // 暂停SP再生
@@ -74,6 +76,25 @@ export class ActionStartHandler implements EventHandler<ActionStartEvent> {
   private isPrepAction(e: ActionStartEvent, ctx: SimulationContext) {
     const prepEnd = Number(ctx.state.team.config.prepDuration) || 0;
     return prepEnd > 0 && e.time < prepEnd - 1e-6;
+  }
+
+  private logRequisiteFailures(e: ActionStartEvent, ctx: SimulationContext): void {
+    const action = ctx.getAction(e.payload.actionId);
+    if (!action) return;
+
+    for (const failure of evaluateSkillRequisites(action, ctx)) {
+      ctx.simLog({
+        type: 'ACTION_REQUISITE_FAILED',
+        time: e.time,
+        payload: {
+          actionId: e.payload.actionId,
+          actorId: e.payload.actorId,
+          skillId: e.payload.skillId,
+          type: e.payload.type,
+          ...failure,
+        },
+      });
+    }
   }
 
   /** Consume all team-wide link stacks when a battle skill or ultimate starts. */

--- a/src/simulation/events/effectDispatch.ts
+++ b/src/simulation/events/effectDispatch.ts
@@ -276,6 +276,9 @@ export function evaluateEffectCondition(
     const cooldownEnd = startTime + cd - cdReduction;
     return time >= cooldownEnd;
   }
+  if (cond.kind === 'ultimateEnhancement') {
+    return ctx.isUltimateEnhancementActive(sourceTrackId, time);
+  }
   if (cond.kind === 'enemyStaggered') {
     return ctx.state.enemy.isBroken(time);
   }

--- a/src/simulation/events/event.types.ts
+++ b/src/simulation/events/event.types.ts
@@ -217,6 +217,18 @@ export type SimLogEntry =
       }
     >
   | SimLogEntryBase<
+      'ACTION_REQUISITE_FAILED',
+      {
+        actionId: string;
+        actorId: string;
+        skillId: string;
+        type: ActionType;
+        requisiteId: string;
+        messageKey?: string;
+        params?: Record<string, unknown>;
+      }
+    >
+  | SimLogEntryBase<
       'ACTION_END',
       {
         skillId: string;

--- a/src/simulation/projection/projectOptimizerResult.ts
+++ b/src/simulation/projection/projectOptimizerResult.ts
@@ -139,6 +139,7 @@ export function projectOptimizerResult(input: ProjectOptimizerResultInput) {
     spSeries,
     gaugeSeriesByTrackId,
     operatorLog,
+    simLog,
   );
 
   return {

--- a/src/simulation/projection/projectRequisiteWarnings.test.ts
+++ b/src/simulation/projection/projectRequisiteWarnings.test.ts
@@ -148,6 +148,75 @@ describe('projectRequisiteWarnings combo queue order', () => {
     expect(warnings.has('chen-combo')).toBe(false);
   });
 
+  it('projects skill-requisite diagnostics emitted by the simulator', () => {
+    const warnings = projectRequisiteWarnings(
+      [{ id: 'laevatain', actions: [{ instanceId: 'enhanced', type: 'battleSkill', startTime: 1 }] }],
+      new Map(),
+      [],
+      new Map(),
+      [],
+      [
+        {
+          type: 'ACTION_REQUISITE_FAILED',
+          time: 1,
+          payload: {
+            actionId: 'enhanced',
+            actorId: 'laevatain',
+            skillId: 'enhancedBattleSkill',
+            type: 'battleSkill',
+            requisiteId: 'laevatain-ultimate-enhancement',
+            messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+          },
+        },
+      ],
+    );
+
+    expect(warnings.get('enhanced')).toEqual({
+      kind: 'skillRequisite',
+      requisiteId: 'laevatain-ultimate-enhancement',
+      messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+      params: undefined,
+    });
+  });
+
+  it('lets skill-requisite diagnostics override generic resource warnings', () => {
+    const warnings = projectRequisiteWarnings(
+      [
+        {
+          id: 'arcane',
+          actions: [
+            { instanceId: 'arcane-ultimate', type: 'ultimate', startTime: 1, gaugeCost: 100 },
+          ],
+        },
+      ],
+      new Map(),
+      [],
+      new Map([['arcane', [{ time: 0, val: 0, ratio: 0 }]]]),
+      [],
+      [
+        {
+          type: 'ACTION_REQUISITE_FAILED',
+          time: 1,
+          payload: {
+            actionId: 'arcane-ultimate',
+            actorId: 'arcane',
+            skillId: 'ultimate',
+            type: 'ultimate',
+            requisiteId: 'arcane-ultimate-arcana-ready',
+            messageKey: 'actionItem.requisiteTitle.arcaneUltimateArcanaRequired',
+          },
+        },
+      ],
+    );
+
+    expect(warnings.get('arcane-ultimate')).toEqual({
+      kind: 'skillRequisite',
+      requisiteId: 'arcane-ultimate-arcana-ready',
+      messageKey: 'actionItem.requisiteTitle.arcaneUltimateArcanaRequired',
+      params: undefined,
+    });
+  });
+
   it('orders split combo-window segments by their original window start', () => {
     const warnings = projectRequisiteWarnings(
       [

--- a/src/simulation/projection/projectRequisiteWarnings.ts
+++ b/src/simulation/projection/projectRequisiteWarnings.ts
@@ -4,6 +4,7 @@ import type { GaugePoint } from './projectUltimateSeries';
 import { snapTimeToFrame } from '@/utils/time';
 import type { ComboWindowLayout } from './projectComboWindows';
 import type { OperatorStateEvent } from '@/simulation/engine/types';
+import type { SimLogEntry } from '@/simulation/events/event.types';
 
 const COMBO_SKILL_TYPE = 'comboSkill';
 const COMBO_WINDOW_EFFECT_ID_SUFFIX = 'combo-window';
@@ -54,7 +55,13 @@ export type RequisiteWarning =
   | { kind: 'comboWindow' }
   | { kind: 'comboOrder'; blockingTrackId: string }
   | { kind: 'sp'; need: number; current: number }
-  | { kind: 'gauge'; need: number; current: number };
+  | { kind: 'gauge'; need: number; current: number }
+  | {
+      kind: 'skillRequisite';
+      requisiteId: string;
+      messageKey?: string;
+      params?: Record<string, unknown>;
+    };
 
 interface RegisteredTriggerEffect {
   sourceTrackId?: string;
@@ -213,11 +220,12 @@ function requiresComboWindowCheck(track: TrackData): boolean {
  * Build a map of actionId → RequisiteWarning for all skill blocks
  * that cannot execute because their prerequisites are unmet.
  *
- * Four checks:
+ * Checks:
  * - comboSkill  → must overlap a combo window (if the operator has one)
  * - comboSkill  → active combo windows must be consumed in queue order
  * - battleSkill → SP_CHANGE log shows sp < 0 after cost deduction
  * - ultimate     → must have enough gauge at start time
+ * - skill-specific release requisites emitted by the simulator
  *
  * Disabled actions (isDisabled) are skipped entirely.
  * Combo checks use frame-snapped times to avoid floating-point drift
@@ -230,6 +238,7 @@ export function projectRequisiteWarnings(
   spSeries: SpPoint[],
   gaugeSeriesByTrackId: Map<string, GaugePoint[]>,
   operatorLog: OperatorStateEvent[] = [],
+  simLog: SimLogEntry[] = [],
 ): Map<string, RequisiteWarning> {
   const warnings = new Map<string, RequisiteWarning>();
   const spIndex = buildSpIndex(spSeries);
@@ -306,6 +315,20 @@ export function projectRequisiteWarnings(
         continue;
       }
     }
+  }
+
+  // Action-spec requisite
+  // Overrides previous checks
+  for (const entry of simLog) {
+    if (entry.type !== 'ACTION_REQUISITE_FAILED') continue;
+    const actionId = entry.payload?.actionId;
+    if (!actionId) continue;
+    warnings.set(actionId, {
+      kind: 'skillRequisite',
+      requisiteId: entry.payload.requisiteId,
+      messageKey: entry.payload.messageKey,
+      params: entry.payload.params,
+    });
   }
 
   return warnings;

--- a/src/simulation/requisites/evaluateSkillRequisites.test.ts
+++ b/src/simulation/requisites/evaluateSkillRequisites.test.ts
@@ -1,0 +1,427 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultStats } from '@/simulation/defaultActorStats';
+import { compileScenario } from '@/simulation/compiler/compileScenario';
+import type { Action, ScenarioData, ScenarioTrack } from '@/simulation/compiler/types';
+import { simulate } from '@/simulation/simulator';
+import type { InitialEffect } from '@/simulation/simulator';
+
+function createAction(id: string, type: Action['type'], patch: Partial<Action> = {}): Action {
+  const startTime = Number(patch.startTime) || 0;
+  return {
+    id,
+    instanceId: `${id}_inst`,
+    type,
+    skillId: patch.skillId || id,
+    name: id,
+    startTime,
+    logicalStartTime: startTime,
+    cooldown: 0,
+    spCost: 0,
+    element: 'heat',
+    gaugeCost: 0,
+    gaugeGain: 0,
+    teamGaugeGain: 0,
+    enhancementTime: 0,
+    duration: 1,
+    triggerWindow: 0,
+    animationTime: 0,
+    hits: [],
+    ...patch,
+  };
+}
+
+function createTrack(actions: Action[], id = 'laevatain'): ScenarioTrack {
+  return {
+    id,
+    actions,
+    stats: createDefaultStats(),
+    gaugeEfficiency: 100,
+    originiumArtsPower: 0,
+    linkCdReduction: 0,
+    initialGauge: 300,
+  };
+}
+
+function run(actions: Action[], trackId = 'laevatain', initialEffects: InitialEffect[] = []) {
+  const scenario: ScenarioData = {
+    tracks: [createTrack(actions, trackId)],
+    connections: [],
+  };
+  const { timeline, teamConfig, enemyConfig, actors } = compileScenario(scenario);
+  return simulate(timeline, teamConfig, enemyConfig, actors, undefined, undefined, {
+    initialEffects,
+  });
+}
+
+const ARCANE_ULTIMATE_ARCANA_REQUISITE = {
+  id: 'arcane-ultimate-arcana-ready',
+  condition: {
+    kind: 'or' as const,
+    conditions: [
+      { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+      { kind: 'operatorStatus' as const, status: 'arcane-gloompurge-arcana-ready' },
+    ],
+  },
+  messageKey: 'actionItem.requisiteTitle.arcaneUltimateArcanaRequired',
+};
+
+const LAEVATAIN_OUTSIDE_ULTIMATE_BASIC_REQUISITE = {
+  id: 'laevatain-basic-outside-ultimate-enhancement',
+  condition: { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+};
+
+const LAEVATAIN_OUTSIDE_ULTIMATE_BATTLE_REQUISITE = {
+  id: 'laevatain-battle-outside-ultimate-enhancement',
+  condition: { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBattleDuringUltimate',
+};
+
+const ZHUANG_FANGYI_DURING_ULTIMATE_REQUISITE = {
+  id: 'zhuang-fangyi-ultimate-enhancement',
+  condition: { kind: 'ultimateEnhancement' as const },
+  messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+};
+
+const ZHUANG_FANGYI_OUTSIDE_ULTIMATE_BASIC_REQUISITE = {
+  id: 'zhuang-fangyi-basic-outside-ultimate-enhancement',
+  condition: { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+};
+
+const ZHUANG_FANGYI_OUTSIDE_ULTIMATE_BATTLE_REQUISITE = {
+  id: 'zhuang-fangyi-battle-outside-ultimate-enhancement',
+  condition: { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBattleDuringUltimate',
+};
+
+const ZHUANG_FANGYI_OUTSIDE_ULTIMATE_COMBO_REQUISITE = {
+  id: 'zhuang-fangyi-combo-outside-ultimate-enhancement',
+  condition: { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+  messageKey: 'actionItem.requisiteTitle.enhancedComboDuringUltimate',
+};
+
+const YVONNE_DURING_ULTIMATE_REQUISITE = {
+  id: 'yvonne-ultimate-enhancement',
+  condition: { kind: 'ultimateEnhancement' as const },
+  messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+};
+
+const YVONNE_OUTSIDE_ULTIMATE_BASIC_REQUISITE = {
+  id: 'yvonne-basic-outside-ultimate-enhancement',
+  condition: { kind: 'not' as const, condition: { kind: 'ultimateEnhancement' as const } },
+  messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+};
+
+describe('evaluateSkillRequisites', () => {
+  it('logs unmet ultimate-enhancement release prerequisites', () => {
+    const result = run([
+      createAction('enhanced', 'battleSkill', {
+        startTime: 1,
+        requisites: [
+          {
+            id: 'laevatain-ultimate-enhancement',
+            condition: { kind: 'ultimateEnhancement' },
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.simLog).toContainEqual(
+      expect.objectContaining({
+        type: 'ACTION_REQUISITE_FAILED',
+        payload: expect.objectContaining({
+          actionId: 'enhanced_inst',
+          requisiteId: 'laevatain-ultimate-enhancement',
+        }),
+      }),
+    );
+  });
+
+  it('passes ultimate-enhancement release prerequisites during the enhancement window', () => {
+    const result = run([
+      createAction('ultimate', 'ultimate', {
+        startTime: 0,
+        gaugeCost: 300,
+        enhancementTime: 5,
+        animationTime: 0,
+      }),
+      createAction('enhanced', 'battleSkill', {
+        startTime: 2,
+        requisites: [
+          {
+            id: 'laevatain-ultimate-enhancement',
+            condition: { kind: 'ultimateEnhancement' },
+          },
+        ],
+      }),
+    ]);
+
+    expect(
+      result.simLog.some(
+        entry =>
+          entry.type === 'ACTION_REQUISITE_FAILED' &&
+          entry.payload.actionId === 'enhanced_inst',
+      ),
+    ).toBe(false);
+  });
+
+  it('blocks Laevatain normal basic attack and battle skill during ultimate enhancement', () => {
+    const result = run([
+      createAction('ultimate', 'ultimate', {
+        startTime: 0,
+        gaugeCost: 300,
+        enhancementTime: 5,
+        animationTime: 0,
+      }),
+      createAction('normal-basic', 'basicAttack', {
+        startTime: 2,
+        requisites: [LAEVATAIN_OUTSIDE_ULTIMATE_BASIC_REQUISITE],
+      }),
+      createAction('normal-battle', 'battleSkill', {
+        startTime: 3,
+        requisites: [LAEVATAIN_OUTSIDE_ULTIMATE_BATTLE_REQUISITE],
+      }),
+    ]);
+
+    const failures = result.simLog.filter(entry => entry.type === 'ACTION_REQUISITE_FAILED');
+
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            actionId: 'normal-basic_inst',
+            requisiteId: 'laevatain-basic-outside-ultimate-enhancement',
+            messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+          }),
+        }),
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            actionId: 'normal-battle_inst',
+            requisiteId: 'laevatain-battle-outside-ultimate-enhancement',
+            messageKey: 'actionItem.requisiteTitle.enhancedBattleDuringUltimate',
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('blocks Zhuang Fangyi normal variants during ultimate enhancement', () => {
+    const result = run(
+      [
+        createAction('ultimate', 'ultimate', {
+          startTime: 0,
+          gaugeCost: 300,
+          enhancementTime: 5,
+          animationTime: 0,
+        }),
+        createAction('normal-basic', 'basicAttack', {
+          startTime: 2,
+          requisites: [ZHUANG_FANGYI_OUTSIDE_ULTIMATE_BASIC_REQUISITE],
+        }),
+        createAction('normal-battle', 'battleSkill', {
+          startTime: 3,
+          requisites: [ZHUANG_FANGYI_OUTSIDE_ULTIMATE_BATTLE_REQUISITE],
+        }),
+        createAction('normal-combo', 'comboSkill', {
+          startTime: 4,
+          requisites: [ZHUANG_FANGYI_OUTSIDE_ULTIMATE_COMBO_REQUISITE],
+        }),
+      ],
+      'zhuang-fangyi',
+    );
+
+    const failedActionIds = result.simLog
+      .filter(entry => entry.type === 'ACTION_REQUISITE_FAILED')
+      .map(entry => entry.payload.actionId);
+
+    expect(failedActionIds).toEqual(
+      expect.arrayContaining(['normal-basic_inst', 'normal-battle_inst', 'normal-combo_inst']),
+    );
+  });
+
+  it('blocks Zhuang Fangyi enhanced variants outside ultimate enhancement', () => {
+    const result = run(
+      [
+        createAction('enhanced-basic', 'basicAttack', {
+          startTime: 1,
+          requisites: [ZHUANG_FANGYI_DURING_ULTIMATE_REQUISITE],
+        }),
+        createAction('enhanced-battle', 'battleSkill', {
+          startTime: 2,
+          requisites: [ZHUANG_FANGYI_DURING_ULTIMATE_REQUISITE],
+        }),
+        createAction('enhanced-combo', 'comboSkill', {
+          startTime: 3,
+          requisites: [ZHUANG_FANGYI_DURING_ULTIMATE_REQUISITE],
+        }),
+      ],
+      'zhuang-fangyi',
+    );
+
+    const failedActionIds = result.simLog
+      .filter(entry => entry.type === 'ACTION_REQUISITE_FAILED')
+      .map(entry => entry.payload.actionId);
+
+    expect(failedActionIds).toEqual(
+      expect.arrayContaining(['enhanced-basic_inst', 'enhanced-battle_inst', 'enhanced-combo_inst']),
+    );
+  });
+
+  it('blocks Yvonne normal basic attack during ultimate enhancement', () => {
+    const result = run(
+      [
+        createAction('ultimate', 'ultimate', {
+          startTime: 0,
+          gaugeCost: 300,
+          enhancementTime: 5,
+          animationTime: 0,
+        }),
+        createAction('normal-basic', 'basicAttack', {
+          startTime: 2,
+          requisites: [YVONNE_OUTSIDE_ULTIMATE_BASIC_REQUISITE],
+        }),
+      ],
+      'yvonne',
+    );
+
+    expect(result.simLog).toContainEqual(
+      expect.objectContaining({
+        type: 'ACTION_REQUISITE_FAILED',
+        payload: expect.objectContaining({
+          actionId: 'normal-basic_inst',
+          requisiteId: 'yvonne-basic-outside-ultimate-enhancement',
+          messageKey: 'actionItem.requisiteTitle.enhancedBasicDuringUltimate',
+        }),
+      }),
+    );
+  });
+
+  it('blocks Yvonne enhanced basic attack outside ultimate enhancement', () => {
+    const result = run(
+      [
+        createAction('enhanced-basic', 'basicAttack', {
+          startTime: 1,
+          requisites: [YVONNE_DURING_ULTIMATE_REQUISITE],
+        }),
+      ],
+      'yvonne',
+    );
+
+    expect(result.simLog).toContainEqual(
+      expect.objectContaining({
+        type: 'ACTION_REQUISITE_FAILED',
+        payload: expect.objectContaining({
+          actionId: 'enhanced-basic_inst',
+          requisiteId: 'yvonne-ultimate-enhancement',
+          messageKey: 'actionItem.requisiteTitle.ultimateEnhancementOnly',
+        }),
+      }),
+    );
+  });
+
+  it('blocks Arcane ultimate during enhancement until arcana is ready', () => {
+    const result = run(
+      [
+        createAction('first-ultimate', 'ultimate', {
+          startTime: 0,
+          gaugeCost: 100,
+          enhancementTime: 'arcane-gloompurger-array',
+          animationTime: 0,
+          requisites: [ARCANE_ULTIMATE_ARCANA_REQUISITE],
+          hits: [
+            {
+              offset: 0,
+              spRecovery: 0,
+              spReturn: 0,
+              stagger: 0,
+              effects: [
+                {
+                  id: 'arcane-gloompurger-array',
+                  kind: 'status',
+                  target: 'self',
+                  duration: 5,
+                },
+              ],
+            },
+          ],
+        }),
+        createAction('second-ultimate', 'ultimate', {
+          startTime: 1,
+          gaugeCost: 100,
+          enhancementTime: 'arcane-gloompurger-array',
+          animationTime: 0,
+          requisites: [ARCANE_ULTIMATE_ARCANA_REQUISITE],
+        }),
+      ],
+      'arcane',
+    );
+
+    expect(result.simLog).toContainEqual(
+      expect.objectContaining({
+        type: 'ACTION_REQUISITE_FAILED',
+        payload: expect.objectContaining({
+          actionId: 'second-ultimate_inst',
+          requisiteId: 'arcane-ultimate-arcana-ready',
+          messageKey: 'actionItem.requisiteTitle.arcaneUltimateArcanaRequired',
+        }),
+      }),
+    );
+  });
+
+  it('allows Arcane ultimate during enhancement after arcana is ready', () => {
+    const result = run(
+      [
+        createAction('first-ultimate', 'ultimate', {
+          startTime: 0,
+          gaugeCost: 100,
+          enhancementTime: 'arcane-gloompurger-array',
+          animationTime: 0,
+          requisites: [ARCANE_ULTIMATE_ARCANA_REQUISITE],
+          hits: [
+            {
+              offset: 0,
+              spRecovery: 0,
+              spReturn: 0,
+              stagger: 0,
+              effects: [
+                {
+                  id: 'arcane-gloompurger-array',
+                  kind: 'status',
+                  target: 'self',
+                  duration: 5,
+                },
+              ],
+            },
+          ],
+        }),
+        createAction('second-ultimate', 'ultimate', {
+          startTime: 1,
+          gaugeCost: 100,
+          enhancementTime: 'arcane-gloompurger-array',
+          animationTime: 0,
+          requisites: [ARCANE_ULTIMATE_ARCANA_REQUISITE],
+        }),
+      ],
+      'arcane',
+      [
+        {
+          kind: 'status',
+          targetTrackId: 'arcane',
+          id: 'arcane-gloompurge-arcana-ready',
+          value: 0,
+          sourceId: 'test',
+          remainingDuration: 5,
+        },
+      ],
+    );
+
+    expect(
+      result.simLog.some(
+        entry =>
+          entry.type === 'ACTION_REQUISITE_FAILED' &&
+          entry.payload.actionId === 'second-ultimate_inst',
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/simulation/requisites/evaluateSkillRequisites.ts
+++ b/src/simulation/requisites/evaluateSkillRequisites.ts
@@ -1,0 +1,72 @@
+import type { EffectCondition, SkillRequisite } from '@/data/types';
+import type { ResolvedAction } from '@/simulation/compiler/types';
+import type { SimulationContext } from '@/simulation/engine/SimulationContext';
+import { evaluateEffectCondition } from '@/simulation/events/effectDispatch';
+
+export interface SkillRequisiteFailure {
+  requisiteId: string;
+  messageKey?: string;
+  params?: Record<string, unknown>;
+}
+
+function assertPureCondition(condition: EffectCondition | EffectCondition[], requisiteId: string) {
+  if (Array.isArray(condition)) {
+    condition.forEach(item => assertPureCondition(item, requisiteId));
+    return;
+  }
+
+  if (condition.kind === 'or') {
+    condition.conditions.forEach(item => assertPureCondition(item, requisiteId));
+    return;
+  }
+
+  if (condition.kind === 'not') {
+    assertPureCondition(condition.condition, requisiteId);
+    return;
+  }
+
+  if (
+    (condition.kind === 'enemyStatus' || condition.kind === 'operatorStatus') &&
+    condition.consume !== undefined
+  ) {
+    throw new Error(`Skill requisite "${requisiteId}" must not consume condition state.`);
+  }
+}
+
+/**
+ * Evaluates release-time prerequisites against live simulation state.
+ *
+ * The check is diagnostic-only: unmet requisites are logged for the editor, but
+ * the simulator keeps executing the action so existing projects remain readable.
+ */
+export function evaluateSkillRequisites(
+  action: ResolvedAction,
+  ctx: SimulationContext,
+): SkillRequisiteFailure[] {
+  const requisites = action.node.requisites as SkillRequisite[] | undefined;
+  if (!Array.isArray(requisites) || requisites.length === 0) return [];
+
+  const failures: SkillRequisiteFailure[] = [];
+  for (const requisite of requisites) {
+    assertPureCondition(requisite.condition, requisite.id);
+    if (
+      evaluateEffectCondition(
+        requisite.condition,
+        action.realStartTime,
+        action.trackId,
+        ctx,
+        undefined,
+        action.id,
+      )
+    ) {
+      continue;
+    }
+    failures.push({
+      requisiteId: requisite.id,
+      messageKey: requisite.messageKey,
+      params: requisite.params,
+    });
+  }
+
+  return failures;
+}

--- a/src/simulation/simulator.test.ts
+++ b/src/simulation/simulator.test.ts
@@ -2171,6 +2171,58 @@ describe('optimizer-native runtime parity', () => {
     expect(ueEntries.some(entry => entry.payload.sourceId === 'gain-after_inst')).toBe(true);
   });
 
+  it('blocks positive ultimate energy gains during status-bound ultimate enhancement window', () => {
+    const simulation = runScenario([
+      createTrack(
+        'alpha',
+        [
+          createAction('ult', 'ultimate', {
+            startTime: 0,
+            duration: 2,
+            animationTime: 1,
+            enhancementTime: 'arcane-gloompurger-array',
+            gaugeCost: 50,
+            hits: [
+              {
+                offset: 1,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [
+                  {
+                    id: 'arcane-gloompurger-array',
+                    kind: 'status',
+                    target: 'self',
+                    duration: 5,
+                  },
+                ],
+              },
+            ],
+          }),
+          createAction('gain-inside', 'comboSkill', {
+            startTime: 2,
+            duration: 1,
+            gaugeGain: 10,
+          }),
+          createAction('gain-after', 'comboSkill', {
+            startTime: 7,
+            duration: 1,
+            gaugeGain: 10,
+          }),
+        ],
+        {
+          initialGauge: 50,
+          maxGaugeOverride: 100,
+        },
+      ),
+    ]);
+
+    const ueEntries = simulation.simLog.filter(entry => entry.type === 'ULT_ENERGY_CHANGE');
+
+    expect(ueEntries.some(entry => entry.payload.sourceId === 'gain-inside_inst')).toBe(false);
+    expect(ueEntries.some(entry => entry.payload.sourceId === 'gain-after_inst')).toBe(true);
+  });
+
   it('maps optimizer enemy effect layout into ResourceMonitor affliction groups', () => {
     const viz = projectEnemyAfflictionViz({
       positionedSegments: [

--- a/src/stores/timeline/resolveHits.ts
+++ b/src/stores/timeline/resolveHits.ts
@@ -528,6 +528,7 @@ export function buildResolvedSegmentPayload(
       duration: Number(segment?.duration) || 0,
       followupDelay,
       ...(segmentSkillId ? { skillId: segmentSkillId } : {}),
+      ...(segment?.requisites ? { requisites: segment.requisites } : {}),
       ...(segment?.spCost != null ? { spCost: Number(segment.spCost) || 0 } : {}),
       payload: {
         hits: segmentSkillId ? hits.map(hit => ({ ...hit, skillId: segmentSkillId })) : hits,

--- a/src/stores/timeline/skillLibrary.ts
+++ b/src/stores/timeline/skillLibrary.ts
@@ -112,6 +112,11 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
       return Math.max(0, Math.min((Number.isFinite(rawLevel) ? rawLevel : 1) - 1, 11));
     };
 
+    const resolveEnhancementTime = (value: unknown) => {
+      if (typeof value === 'string' && value.length > 0) return value;
+      return Number(value) || 0;
+    };
+
     const buildSegmentModels = (
       skillIdBase: string,
       skill: Record<string, unknown>,
@@ -149,6 +154,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
       enhancementTime?: any;
       animationTime?: any;
       payload?: any;
+      requisites?: any;
       override?: Record<string, unknown>;
       extra?: Record<string, unknown>;
       sourceSkillKey?: string;
@@ -171,6 +177,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
       enhancementTime = 0,
       animationTime = 0,
       payload,
+      requisites,
       override = {},
       extra = {},
       sourceSkillKey = skillId,
@@ -193,6 +200,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
         teamGaugeGain,
         enhancementTime,
         animationTime,
+        ...(Array.isArray(requisites) && requisites.length ? { requisites } : {}),
         hits: cloneJsonData(safePayload.hits) || [],
         sourceSkillKey,
         ...(override && typeof override === 'object' ? override : {}),
@@ -228,6 +236,13 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
       const skillKey = skill.skillKey || skill.type;
       const cooldown = resolveLevelNumber(skill?.cooldown, levelIndex, 0);
       const segmentData = buildSegmentModels(skillIdBase, skill, levelIndex);
+      const skillRequisites = Array.isArray(skill.requisites) ? skill.requisites : [];
+      const mergeRequisites = (segmentInfo?: Record<string, unknown> | null) => {
+        const segmentRequisites = Array.isArray(segmentInfo?.requisites)
+          ? segmentInfo.requisites
+          : [];
+        return [...skillRequisites, ...segmentRequisites];
+      };
       const gaugeGainDefault =
         skill.type === 'battleSkill'
           ? Number(skill?.ultimateEnergyGain ?? DEFAULT_BATTLE_SKILL_UE) || 0
@@ -239,7 +254,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
         gaugeCost: skill.type === 'ultimate' ? Number(skill?.ultimateEnergyCost) || 100 : 0,
         gaugeGain: gaugeGainDefault,
         teamGaugeGain: skill.type === 'battleSkill' ? gaugeGainDefault : 0,
-        enhancementTime: Number(skill?.enhancementTime) || 0,
+        enhancementTime: resolveEnhancementTime(skill?.enhancementTime),
         animationTime:
           skill.type === 'ultimate'
             ? Number(skill?.animationTime) || 0.5
@@ -279,6 +294,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
             icon,
             duration: segmentInfo.duration,
             payload: segmentInfo.payload,
+            requisites: mergeRequisites(segmentInfo),
             override: mergedOverride,
             extra: {
               kind: 'attack_segment',
@@ -311,6 +327,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
             0,
           ),
           payload: segmentData.aggregatePayload,
+          requisites: skillRequisites,
           override: groupOverrideRaw,
           extra: {
             kind: 'attack_group',
@@ -364,6 +381,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
             enhancementTime: idx === 0 ? baseDefaults.enhancementTime : 0,
             animationTime: idx === 0 ? baseDefaults.animationTime : 0,
             payload: segmentInfo.payload,
+            requisites: mergeRequisites(segmentInfo),
             override: segOverride,
             sourceSkillKey: skillId,
             extra: {
@@ -392,6 +410,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
           enhancementTime: baseDefaults.enhancementTime,
           animationTime: baseDefaults.animationTime,
           payload: segmentData.aggregatePayload,
+          requisites: skillRequisites,
           override: globalOverride,
           extra: {
             kind: 'group',
@@ -422,6 +441,7 @@ export function useSkillLibrary(deps: SkillLibraryDeps) {
         enhancementTime: baseDefaults.enhancementTime,
         animationTime: baseDefaults.animationTime,
         payload: segmentData.aggregatePayload,
+        requisites: mergeRequisites(segmentData.segmentPayloads[0]),
         override: globalOverride,
       });
     };

--- a/src/stores/timeline/types.ts
+++ b/src/stores/timeline/types.ts
@@ -4,6 +4,8 @@
 // transient fields — so the sprawling objects declare their common fields and
 // keep an index signature for the rest. Phase 2b decomposition builds on these.
 
+import type { SkillRequisite } from '@/data/types';
+
 /** A skill/action instance placed on a track's timeline. */
 export interface TimelineAction {
   id?: string;
@@ -32,6 +34,10 @@ export interface TimelineAction {
   attackGroupName?: string;
   attackSequenceIndex?: number;
   attackSequenceTotal?: number;
+  skillKey?: string;
+  // TODO: requisites 是由技能身份和当前技能表推导出的运行时字段。
+  //  后续整理存档 schema 时，应在 autosave/export 前剥离，并在加载/编译前统一刷新。
+  requisites?: SkillRequisite[];
   forcedCritHits?: number[];
   locked?: boolean;
   disabled?: boolean;

--- a/src/stores/timelineStore.ts
+++ b/src/stores/timelineStore.ts
@@ -2809,12 +2809,18 @@ export const useTimelineStore = defineStore('timeline', () => {
 
   interface FlatSkillLike {
     segments?: (Segment | undefined)[];
+    requisites?: unknown[];
     levelKey?: string;
     cooldown?: number | number[];
     type?: string;
     animationTime?: number;
-    enhancementTime?: number;
+    enhancementTime?: number | string;
     [key: string]: unknown;
+  }
+
+  function resolveEnhancementTime(value: unknown) {
+    if (typeof value === 'string' && value.length > 0) return value;
+    return Number(value) || 0;
   }
 
   function resolveActionRefreshPayload(
@@ -2824,18 +2830,24 @@ export const useTimelineStore = defineStore('timeline', () => {
     levelIndex: number,
   ) {
     const segmentIndex = getActionSegmentIndex(action);
+    const skillRequisites = Array.isArray(flatSkill?.requisites) ? flatSkill.requisites : [];
     if (segmentIndex !== null) {
       const segment = flatSkill?.segments?.[segmentIndex];
       const segmentEntries = segment ? extractRawEntries({ segments: [segment] }, 0) : [];
+      const segmentRequisites = Array.isArray(segment?.requisites) ? segment.requisites : [];
       return {
         rawEntries: segmentEntries,
         duration: Number(segment?.duration) || 0,
         element: segment?.damageGroups?.find(group => group?.element)?.element || action.element,
+        requisites: [...skillRequisites, ...segmentRequisites],
       };
     }
 
     const aggregateRawEntries = extractAggregateRawEntries(flatSkill);
     const segmentPayload = buildResolvedSegmentPayload(skillIdBase, flatSkill, levelIndex);
+    const firstSegmentRequisites = Array.isArray(segmentPayload.segmentPayloads?.[0]?.requisites)
+      ? segmentPayload.segmentPayloads[0].requisites
+      : [];
     return {
       rawEntries: aggregateRawEntries,
       duration: Math.max(
@@ -2843,6 +2855,7 @@ export const useTimelineStore = defineStore('timeline', () => {
         Number(segmentPayload.totalDuration) || Number(flatSkill?.segments?.[0]?.duration) || 0,
       ),
       element: segmentPayload.element || action.element,
+      requisites: [...skillRequisites, ...firstSegmentRequisites],
     };
   }
 
@@ -2887,13 +2900,16 @@ export const useTimelineStore = defineStore('timeline', () => {
       if (refreshPayload.element) {
         action.element = refreshPayload.element;
       }
+      action.requisites = Array.isArray(refreshPayload.requisites)
+        ? refreshPayload.requisites
+        : [];
 
       if (flatSkill.cooldown != null && !action.comboSegmentIndex && !action.attackSegmentIndex) {
         action.cooldown = resolveLevelNumber(flatSkill.cooldown, levelIndex, action.cooldown || 0);
       }
       if (flatSkill.type === 'ultimate') {
         action.animationTime = Number(flatSkill.animationTime) || 0;
-        action.enhancementTime = Number(flatSkill.enhancementTime) || 0;
+        action.enhancementTime = resolveEnhancementTime(flatSkill.enhancementTime);
       }
     });
   }
@@ -5143,13 +5159,12 @@ export const useTimelineStore = defineStore('timeline', () => {
         if (isUltimateLikeAction(action) && !action.isDisabled) {
           const start = snapTimeToFrame(action.startTime);
           const animT = Number(action.animationTime || 0);
-          const enhT = Number(action.enhancementTime || 0);
+          const rawEnhancementTime = action.enhancementTime;
+          const enhT = typeof rawEnhancementTime === 'string' ? 0 : Number(rawEnhancementTime || 0);
 
           let end: number | null = null;
-          if (typeof getUltimateEnhancementExtender(trackId) === 'function' && enhT > 0) {
-            const metrics = getUltimateEnhancementMetrics(action.instanceId ?? '');
-            if (metrics?.finalEnd) end = snapTimeToFrame(metrics.finalEnd);
-          }
+          const metrics = getUltimateEnhancementMetrics(action.instanceId ?? '');
+          if (metrics?.finalEnd) end = snapTimeToFrame(metrics.finalEnd);
 
           if (!end) {
             end = snapTimeToFrame(


### PR DESCRIPTION
# PR: 新增技能释放前置条件诊断，并修复终结技强化期间回能阻断

## 背景

当前时间轴编辑器已经可以检查通用资源类约束，例如技力、终结技能量、连携窗口等。但部分干员存在更细的技能释放规则：某些技能只能在终结技强化期间释放，某些普通技能在终结技强化期间应切换为强化版本，诀在终结技强化期间再次释放终结技还需要额外满足状态条件。

本 PR 引入一套数据驱动的技能释放前置条件诊断框架，让干员技能数据可以声明自己的释放条件，并由模拟器在动作开始时基于实时战斗状态进行判断。

## 主要改动

- 新增 `SkillRequisite` 数据结构，用于在技能、子技能、技能段上声明释放前置条件。
- 扩展 `EffectCondition`，新增 `ultimateEnhancement` 条件，用于判断干员是否处于自身终结技强化窗口内。
- 新增 `evaluateSkillRequisites`，复用现有 `evaluateEffectCondition` 判断条件，不另起一套条件解释器。
- 在 `ActionStartHandler` 中检查当前动作的前置条件，并通过 `ACTION_REQUISITE_FAILED` 写入模拟日志。
- 将模拟日志中的前置条件失败投影到时间轴警告系统，用于技能块角标和 tooltip 展示。
- 在技能库构建和存档/历史恢复刷新流程中携带并刷新 `requisites`，让旧存档加载后也能基于当前技能数据重新获得前置条件。
- 支持 `enhancementTime` 为字符串状态 ID，解决诀这类“强化窗口绑定到运行时状态”的建模需求。
- 修复终结技强化期间正向终结技能量获取没有被正确阻断的问题，包含固定时长强化窗口和状态绑定强化窗口两种情况。

## 已接入的干员规则

- 莱万汀
  - 强化普攻、强化战技只能在终结技强化期间释放。
  - 终结技强化期间释放普通普攻/普通战技时给出提示，应使用对应强化技能。

- 庄方宜
  - 强化普攻、强化战技、强化连携只能在终结技强化期间释放。
  - 终结技强化期间释放普通普攻/普通战技/普通连携时给出提示，应使用对应强化技能。

- Yvonne
  - 强化普攻只能在终结技强化期间释放。
  - 终结技强化期间释放普通普攻时给出提示，应使用强化普攻。

- 诀
  - 终结技强化期间，如果未满足 `arcane-gloompurge-arcana-ready`，再次释放终结技会给出提示：需要先进行两次重击或处决。

## 实现说明

这次改造把“技能是否可释放”的角色特化逻辑放在干员数据文件中，而不是集中写死在投影层：

- 数据层声明 `requisites`。
- 技能库/存档刷新流程把 `requisites` 合并到实际时间轴动作上。
- 模拟层在动作开始时用实时战斗状态判断条件。
- 投影层只负责把模拟日志转换成 UI warning。
- UI 层只负责根据 `messageKey` 做 i18n 渲染。

这样后续新增干员规则时，优先只需要补充对应干员的技能数据，避免继续扩大 `projectRequisiteWarnings` 的角色分支。

## i18n

新增释放条件相关文案：

- `actionItem.requisiteTitle.skillRequisiteFallback`
- `actionItem.requisiteTitle.ultimateEnhancementOnly`
- `actionItem.requisiteTitle.enhancedBasicDuringUltimate`
- `actionItem.requisiteTitle.enhancedBattleDuringUltimate`
- `actionItem.requisiteTitle.enhancedComboDuringUltimate`
- `actionItem.requisiteTitle.arcaneUltimateArcanaRequired`
- `battleLog.types.ACTION_REQUISITE_FAILED`

已同步中文、英文、俄文 locale。

## 测试

新增/更新了以下覆盖：

- `src/simulation/requisites/evaluateSkillRequisites.test.ts`
  - 前置条件失败会写入 `ACTION_REQUISITE_FAILED`。
  - 终结技强化窗口内/外的增强技能、普通技能互斥规则。
  - 诀终结技强化期间二次终结技的状态前置条件。

- `src/simulation/projection/projectRequisiteWarnings.test.ts`
  - 模拟器发出的前置条件失败可以投影为技能块 warning。
  - 技能特定前置条件 warning 可以覆盖通用资源 warning。

- `src/simulation/simulator.test.ts`
  - 固定时长终结技强化窗口内阻断正向终结技能量获取。
  - 状态绑定终结技强化窗口内阻断正向终结技能量获取。

本地验证命令：

```bash
npm run test -- src/simulation/projection/projectRequisiteWarnings.test.ts src/simulation/requisites/evaluateSkillRequisites.test.ts
```

## Review 关注点

- `requisites` 目前会进入时间轴 action 对象；它本质上是由技能身份和当前技能表推导出的运行时字段。后续整理存档 schema 时，可以考虑在导出/持久化前剥离，并在加载或编译前统一刷新。
- `isUltimateEnhancementActive` 当前复用 `isUltimateEnergyBlocked`，语义上可工作，但函数边界后续可以继续整理。
- `evaluateSkillRequisites` 会拒绝带 consume 的条件，避免诊断检查修改模拟状态。
