### PR TITLE
Fix: 阵诀智模拟、长息范围、失衡上限与伤害分析默认归属

### DIFF
--- a/src/components/ActionItem.vue
+++ b/src/components/ActionItem.vue
@@ -543,6 +543,9 @@ const renderableHits = computed(() => {
     .map(([id, action]) => ({ id, start: action.realStartTime }))
     .sort((left, right) => right.start - left.start);
 
+  const timeOwnerOnThisTrack = time =>
+    trackActionStarts.find(item => item.start <= time)?.id === props.action.instanceId;
+
   const triggeredHits = (store.simLog || [])
     .filter(entry => entry.type === 'DAMAGE_HIT')
     .filter(entry => entry.payload.hitData?.triggered)
@@ -552,15 +555,20 @@ const renderableHits = computed(() => {
     .filter(entry => {
       const actionId = entry.payload.actionId;
       if (
-        actionId &&
-        !String(actionId).startsWith('triggered:') &&
-        !String(actionId).startsWith('reaction:') &&
-        !String(actionId).startsWith('dot:')
+        !actionId ||
+        String(actionId).startsWith('triggered:') ||
+        String(actionId).startsWith('reaction:') ||
+        String(actionId).startsWith('dot:')
       ) {
-        return actionId === props.action.instanceId;
+        return timeOwnerOnThisTrack(entry.time);
       }
-      const owner = trackActionStarts.find(item => item.start <= entry.time);
-      return owner?.id === props.action.instanceId;
+      // Global procs (e.g. Arcane cluster strike) keep the triggering strike's actionId,
+      // which may be on another track — fall back to time ownership on the damage source track.
+      const attributed = store.compiledTimeline?.actionMap.get(String(actionId));
+      if (!attributed || attributed.trackId !== resolvedAction.trackId) {
+        return timeOwnerOnThisTrack(entry.time);
+      }
+      return actionId === props.action.instanceId;
     })
     .filter(entry => !isCoveredBeforeStart(entry.time))
     .map(entry => {

--- a/src/components/DamageAnalysisDialog.vue
+++ b/src/components/DamageAnalysisDialog.vue
@@ -193,19 +193,6 @@ const elementChartOption = computed<ChartOption>(() => ({
               <h3 class="chart-title">{{ t('timeline.analysis.contributionByOperator') }}</h3>
               <div class="lmdi-mode-toggle">
                 <el-tooltip
-                  :content="t('timeline.analysis.lmdiModeStacksTip')"
-                  placement="top"
-                  :show-after="300"
-                >
-                  <button
-                    class="lmdi-mode-btn"
-                    :class="{ active: store.lmdiAttributionMode === 'stacks' }"
-                    @click="store.lmdiAttributionMode = 'stacks'"
-                  >
-                    {{ t('timeline.analysis.lmdiModeStacks') }}
-                  </button>
-                </el-tooltip>
-                <el-tooltip
                   :content="t('timeline.analysis.lmdiModeApplierTip')"
                   placement="top"
                   :show-after="300"
@@ -216,6 +203,19 @@ const elementChartOption = computed<ChartOption>(() => ({
                     @click="store.lmdiAttributionMode = 'applier'"
                   >
                     {{ t('timeline.analysis.lmdiModeApplier') }}
+                  </button>
+                </el-tooltip>
+                <el-tooltip
+                  :content="t('timeline.analysis.lmdiModeStacksTip')"
+                  placement="top"
+                  :show-after="300"
+                >
+                  <button
+                    class="lmdi-mode-btn"
+                    :class="{ active: store.lmdiAttributionMode === 'stacks' }"
+                    @click="store.lmdiAttributionMode = 'stacks'"
+                  >
+                    {{ t('timeline.analysis.lmdiModeStacks') }}
                   </button>
                 </el-tooltip>
               </div>

--- a/src/components/PropertiesPanel.vue
+++ b/src/components/PropertiesPanel.vue
@@ -19,10 +19,11 @@ import {
   toLegacyDisplayType,
   toPersistedEditorHits,
 } from '@/utils/hitModel';
+import { translateEffectName } from '@/editor/hits/statusOptions';
 
 const store = useTimelineStore();
 const connectionHandler = useDragConnection();
-const { t, tm } = useI18n({ useScope: 'global' });
+const { t, te, tm } = useI18n({ useScope: 'global' });
 const props = defineProps({
   onResetPanel: {
     type: Function,
@@ -285,6 +286,33 @@ function timeValueFromFrame(value) {
 function updateActionFrameProp(key, value) {
   updateActionProp(key, timeValueFromFrame(value));
 }
+
+function kebabToCamel(value) {
+  return String(value || '').replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+}
+
+/** Status-bound ultimate enhancement (`enhancementTime: '<statusId>'`). */
+const statusBoundEnhancementId = computed(() => {
+  const value = targetData.value?.enhancementTime;
+  return typeof value === 'string' && value.length > 0 ? value : '';
+});
+
+const statusBoundEnhancementLabel = computed(() => {
+  const statusId = statusBoundEnhancementId.value;
+  if (!statusId) return '';
+  const candidates = [statusId, kebabToCamel(statusId)];
+  const dash = statusId.indexOf('-');
+  if (dash > 0) candidates.push(kebabToCamel(statusId.slice(dash + 1)));
+  let statusName = statusId;
+  for (const candidate of candidates) {
+    const translated = translateEffectName(t, te, candidate);
+    if (translated && translated !== candidate) {
+      statusName = translated;
+      break;
+    }
+  }
+  return t('propertiesPanel.labels.enhancementFollowsStatus', { status: statusName });
+});
 
 function addDamageTick() {
   const currentTicks = [
@@ -690,7 +718,15 @@ function handleStartConnection(id, type = null) {
 
           <div class="form-group compact" v-if="currentSkillType === 'ultimate'">
             <label>{{ t('propertiesPanel.labels.enhancementTimeS') }}</label>
+            <div
+              v-if="statusBoundEnhancementLabel"
+              class="readonly-field"
+              :title="statusBoundEnhancementId"
+            >
+              {{ statusBoundEnhancementLabel }}
+            </div>
             <CustomNumberInput
+              v-else
               :model-value="frameValue(targetData.enhancementTime || 0)"
               @update:model-value="val => updateActionFrameProp('enhancementTime', val)"
               :step="1"
@@ -1273,6 +1309,20 @@ function handleStartConnection(id, type = null) {
   color: #999;
   margin-bottom: 2px;
   display: block;
+}
+.readonly-field {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 8px;
+  border: 1px solid #b37feb;
+  border-radius: 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 12px;
+  text-align: center;
+  background: rgba(179, 127, 235, 0.08);
+  box-sizing: border-box;
 }
 .header-left label {
   font-size: 12px;

--- a/src/data/gearsets/eternal-xiranite.ts
+++ b/src/data/gearsets/eternal-xiranite.ts
@@ -20,7 +20,11 @@ const sheet: GearSetSheet = {
         {
           id: 'eternal-xiranite-set',
           kind: 'status',
-          stat: { modifier: 'dmgBonus' },
+          // Element-scoped so reactions/burst get it (unscoped = 所有技能伤害加成 only).
+          stat: {
+            modifier: 'dmgBonus',
+            elements: ['physical', 'heat', 'cryo', 'electric', 'nature'],
+          },
           target: 'teamExcludeSelf',
           value: 16,
           duration: 15,
@@ -38,7 +42,10 @@ const sheet: GearSetSheet = {
         {
           id: 'eternal-xiranite-set',
           kind: 'status',
-          stat: { modifier: 'dmgBonus' },
+          stat: {
+            modifier: 'dmgBonus',
+            elements: ['physical', 'heat', 'cryo', 'electric', 'nature'],
+          },
           target: 'teamExcludeSelf',
           value: 16,
           duration: 15,

--- a/src/data/gearsets/hot-work.ts
+++ b/src/data/gearsets/hot-work.ts
@@ -32,7 +32,7 @@ const sheet: GearSetSheet = {
           target: 'self',
           value: 50,
           duration: 10,
-          icon: '/equipment/item_equip_t4_suit_fire_natr01_edc_02.webp',
+          icon: '/equipment/fire_natr01/item_equip_t4_suit_fire_natr01_edc_02.webp',
         },
       ],
     },

--- a/src/data/operators/arcane.ts
+++ b/src/data/operators/arcane.ts
@@ -420,6 +420,11 @@ const sheet: OperatorSheet = {
                     kind: 'consume',
                     enemyStatus: 'arcane-imprisonment',
                   },
+                  // Detonate also clears the combo-applied susceptibility.
+                  {
+                    kind: 'consume',
+                    enemyStatus: 'arcane-combo-susceptibility',
+                  },
                   {
                     kind: 'spReturn',
                     value: [28, 28, 28, 28, 28, 28, 28, 28, 28, 30, 30, 30],
@@ -429,8 +434,9 @@ const sheet: OperatorSheet = {
                     },
                   },
                   {
+                    // Distinct id so a later combo cannot refresh/cancel this 2s grant.
                     kind: 'status',
-                    id: 'arcane-combo-susceptibility',
+                    id: 'arcane-combo-susceptibility-detonate',
                     name: 'natureCryoSusceptibility',
                     icon: '/operators/arcane/icon_battle_buff_lizhiyan_combo_vulnerable.webp',
                     target: 'enemy',
@@ -505,6 +511,7 @@ const sheet: OperatorSheet = {
                             kind: 'status',
                             target: 'self',
                             duration: 20,
+                            applyTiming: 'beforeDamage',
                           },
                           {
                             id: 'arcane-ultimate-cluster-strike-counter',
@@ -520,6 +527,7 @@ const sheet: OperatorSheet = {
                             kind: 'reaction',
                             reactionType: 'corrosion',
                             duration: 15,
+                            applyTiming: 'beforeDamage',
                           },
                         ],
                       },
@@ -708,6 +716,17 @@ const sheet: OperatorSheet = {
               {
                 kind: 'patchEffect',
                 targetEffect: 'arcane-combo-susceptibility',
+                skillLevelKey: 'comboSkill',
+                effect: {
+                  scaling: {
+                    additive: [6],
+                    cap: [13, 13, 13, 13, 13, 13, 13, 13, 13.5, 13.5, 13.5, 14],
+                  },
+                },
+              },
+              {
+                kind: 'patchEffect',
+                targetEffect: 'arcane-combo-susceptibility-detonate',
                 skillLevelKey: 'comboSkill',
                 effect: {
                   scaling: {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -387,7 +387,7 @@ export interface EffectBase {
   /**
    * Hit-attached effects normally apply after the hit damage is calculated.
    * `beforeDamage` lets a specific hit effect apply first when its own hit must
-   * benefit from triggers caused by that effect.
+   * benefit from that effect (e.g. self buffs / enemy reactions that feed the hit).
    */
   applyTiming?: ApplyTiming;
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -934,6 +934,7 @@
       "spCost": "SP Cost",
       "gaugeCost": "Charge Cost",
       "enhancementTimeS": "Enhancement Time (f)",
+      "enhancementFollowsStatus": "Follows {status}",
       "followupDelayS": "Next Delay (f)",
       "comboSegment": "Combo Segment",
       "comboLink": "Combo Link"

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -817,6 +817,7 @@
       "spCost": "Расход ОН",
       "gaugeCost": "Стоимость заряда",
       "enhancementTimeS": "Время усиления (f)",
+      "enhancementFollowsStatus": "Следует за {status}",
       "followupDelayS": "Задержка до следующей (f)",
       "comboSegment": "Сегмент комбо",
       "comboLink": "Связь комбо"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -934,6 +934,7 @@
       "spCost": "技力消耗",
       "gaugeCost": "充能消耗",
       "enhancementTimeS": "强化时间(f)",
+      "enhancementFollowsStatus": "跟随{status}",
       "followupDelayS": "下一段间隔(f)",
       "comboSegment": "连携段",
       "comboLink": "连携绑定"

--- a/src/simulation/arcaneClusterStrike.test.ts
+++ b/src/simulation/arcaneClusterStrike.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from 'vitest';
+import arcaneSheet from '@/data/operators/arcane';
+import { applyForm } from '@/data/forms';
+import { collectTriggerEffects, patchCombatSkills } from '@/data/collect';
+import type { Action, ScenarioData, ScenarioTrack } from './compiler/types';
+import { compileScenario } from './compiler/compileScenario';
+import { simulate } from './simulator';
+import { TriggerRegistry } from './engine/TriggerRegistry';
+import { createDefaultStats } from '@/simulation/defaultActorStats';
+import { extractRawEntries, resolveHitsFromSheet } from '@/stores/timeline/resolveHits';
+import type { BaseStatValues } from '@/data/stats/types';
+import type { OperatorInstance, TeamInstance } from '@/types';
+
+const BASE_STATS: BaseStatValues = {
+  level: 60,
+  baseAtk: 1000,
+  baseHp: 1000,
+  weaponAtk: 0,
+  baseAttrs: {
+    strength: 100,
+    agility: 100,
+    intellect: 120,
+    will: 100,
+  },
+  mainAttributeName: 'intellect',
+  secondaryAttributeName: 'will',
+};
+
+function createAction(id: string, type: Action['type'], patch: Partial<Action> = {}): Action {
+  const startTime = Number(patch.startTime) || 0;
+  return {
+    id,
+    instanceId: patch.instanceId || `${id}_inst`,
+    type,
+    skillId: patch.skillId || id,
+    name: patch.name || id,
+    startTime,
+    logicalStartTime: patch.logicalStartTime ?? startTime,
+    cooldown: 0,
+    spCost: 0,
+    spGain: 0,
+    spGainKind: 'recover',
+    element: 'physical',
+    gaugeCost: 0,
+    gaugeGain: 0,
+    teamGaugeGain: 0,
+    enhancementTime: 0,
+    duration: 1,
+    triggerWindow: 0,
+    animationTime: 0,
+    isDisabled: false,
+    hits: [],
+    ...patch,
+  };
+}
+
+function createTrack(id: string, actions: Action[], patch: Partial<ScenarioTrack> = {}): ScenarioTrack {
+  const stats = { ...createDefaultStats(), ...(patch.stats || {}) } as ScenarioTrack['stats'];
+  return {
+    id,
+    actions,
+    stats,
+    baseStats: BASE_STATS,
+    gaugeEfficiency: Number(stats.ult_charge_eff) || 100,
+    originiumArtsPower: Number(stats.originium_arts_power) || 0,
+    linkCdReduction: Number(stats.link_cd_reduction) || 0,
+    initialGauge: 0,
+    maxGaugeOverride: null,
+    acceptTeamGauge: true,
+    ...patch,
+  };
+}
+
+function resolveArcaneUltimateHits(levelIndex = 11) {
+  const intFormSheet = applyForm(arcaneSheet, 'int');
+  const flatSkills = patchCombatSkills(intFormSheet, { talentStates: {}, potential: 0 });
+  const segment = flatSkills.ultimate?.segments?.[0];
+  const rawEntries = extractRawEntries({ segments: [segment] }, 0);
+  return resolveHitsFromSheet([], rawEntries, levelIndex, { preserveCondition: true });
+}
+
+function collectArcaneTriggers(tracks: ScenarioTrack[]) {
+  const team: TeamInstance = {
+    id: 'team',
+    name: 'team',
+    slots: [
+      {
+        operatorId: 'op_arcane',
+        weaponId: null,
+        gear: { armor: null, gloves: null, kit1: null, kit2: null },
+      },
+      {
+        operatorId: 'op_ally',
+        weaponId: null,
+        gear: { armor: null, gloves: null, kit1: null, kit2: null },
+      },
+      { operatorId: null, weaponId: null, gear: { armor: null, gloves: null, kit1: null, kit2: null } },
+      { operatorId: null, weaponId: null, gear: { armor: null, gloves: null, kit1: null, kit2: null } },
+    ],
+  };
+  const arcane = {
+    id: 'op_arcane',
+    operatorSlug: 'arcane',
+    level: 60,
+    promoted: true,
+    potential: 0,
+    skillLevels: { basicAttack: 1, battleSkill: 9, comboSkill: 9, ultimate: 9 },
+    talentStates: {},
+    trustLevel: 0,
+  } satisfies OperatorInstance;
+  const ally = { ...arcane, id: 'op_ally', operatorSlug: 'estella' } satisfies OperatorInstance;
+  const entries = collectTriggerEffects(team, [arcane, ally], [], [], new Map());
+  return entries.map(entry => ({
+    ...entry,
+    sourceTrackId: tracks[entry.sourceSlotIndex]?.id ?? entry.sourceOperatorSlug,
+  }));
+}
+
+function runArcaneScenario(
+  allyAction: Action,
+  options: {
+    controlledOperatorSegments?: { startTime: number; operatorId: string | null }[];
+    initialEnemyState?: any;
+    systemConstants?: Record<string, any>;
+  } = {},
+) {
+  const ultimateHits = resolveArcaneUltimateHits();
+  const tracks = [
+    createTrack('arcane', [
+      createAction('arcane_ult', 'ultimate', {
+        instanceId: 'arcane_ult_inst',
+        startTime: 0,
+        duration: 2.417,
+        animationTime: 1.583,
+        enhancementTime: 'arcane-gloompurger-array',
+        gaugeCost: 100,
+        element: 'nature',
+        hits: ultimateHits,
+      }),
+    ], { initialGauge: 100, maxGaugeOverride: 100 }),
+    createTrack('ally', [allyAction]),
+  ];
+  const triggerEffects = collectArcaneTriggers(tracks);
+  const { timeline, teamConfig, enemyConfig, actors } = compileScenario(
+    { tracks, connections: [] } satisfies ScenarioData,
+    { systemConstants: options.systemConstants },
+  );
+  const baseStatsByTrack = new Map<string, BaseStatValues>(actors.map(a => [a.id, BASE_STATS]));
+  return {
+    tracks,
+    triggerEffects,
+    result: simulate(timeline, teamConfig, enemyConfig, actors, new TriggerRegistry(triggerEffects), undefined, {
+      baseStatsByTrack,
+      enemyDef: 100,
+      controlledOperatorSegments: options.controlledOperatorSegments,
+      initialEnemyState: options.initialEnemyState,
+    }),
+  };
+}
+
+function clusterLasers(simLog: ReturnType<typeof simulate>['simLog']) {
+  return simLog.filter(
+    entry =>
+      entry.type === 'DAMAGE_HIT' &&
+      entry.payload.sourceId === 'arcane' &&
+      entry.payload.hitData?.triggered === true &&
+      entry.payload.hitData?.triggeredBy === 'arcane-ultimate-cluster-strike-counter',
+  );
+}
+
+/** Mirrors ActionItem.vue triggered-hit attribution for an action instance. */
+function actionItemShowsTriggeredHit(
+  actionInstanceId: string,
+  trackId: string,
+  actionStartsOnTrack: Array<{ id: string; start: number }>,
+  actionMap: Map<string, { trackId: string }>,
+  hitTime: number,
+  hit: { sourceId?: string; actionId?: string; triggered?: boolean },
+): boolean {
+  if (!hit.triggered) return false;
+  if (hit.sourceId !== trackId) return false;
+
+  const timeOwnerOnThisTrack = () =>
+    [...actionStartsOnTrack]
+      .sort((a, b) => b.start - a.start)
+      .find(item => item.start <= hitTime)?.id === actionInstanceId;
+
+  const actionId = hit.actionId;
+  if (
+    !actionId ||
+    String(actionId).startsWith('triggered:') ||
+    String(actionId).startsWith('reaction:') ||
+    String(actionId).startsWith('dot:')
+  ) {
+    return timeOwnerOnThisTrack();
+  }
+
+  const attributed = actionMap.get(String(actionId));
+  if (!attributed || attributed.trackId !== trackId) {
+    return timeOwnerOnThisTrack();
+  }
+  return actionId === actionInstanceId;
+}
+
+describe('Arcane ultimate cluster strike (集束打击)', () => {
+  it('applies cluster counter from ultimate hit', () => {
+    const { result } = runArcaneScenario(
+      createAction('ally_ba', 'basicAttack', {
+        instanceId: 'ally_ba_inst',
+        startTime: 99,
+        attackSequenceIndex: 5,
+        attackSequenceTotal: 5,
+        hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+      }),
+    );
+    expect(result.operatorLog).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'OPERATOR_EFFECT_APPLY',
+          id: 'arcane-ultimate-cluster-strike-counter',
+          targetTrackId: 'arcane',
+          stacks: 2,
+        }),
+      ]),
+    );
+  });
+
+  it('fires 4 triggered nature lasers on ally final basicAttack strike', () => {
+    const allyFinal = createAction('ally_final', 'basicAttack', {
+      instanceId: 'ally_final_inst',
+      startTime: 5,
+      attackSequenceIndex: 5,
+      attackSequenceTotal: 5,
+      hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+    });
+    const { result } = runArcaneScenario(allyFinal);
+    const lasers = clusterLasers(result.simLog);
+    expect(lasers).toHaveLength(4);
+    expect(lasers.every(l => l.payload.hitData.element === 'nature')).toBe(true);
+    const offsets = lasers.map(l => l.time - 5).sort((a, b) => a - b);
+    expect(offsets[0]).toBeCloseTo(0.4, 2);
+    expect(offsets[3]).toBeCloseTo(0.799, 2);
+    expect(lasers.every(l => l.payload.sourceId === 'arcane')).toBe(true);
+    expect(lasers.every(l => l.payload.actionId === 'ally_final_inst')).toBe(true);
+  });
+
+  it('fires 4 triggered lasers on ally finisher', () => {
+    const allyFinisher = createAction('ally_finisher', 'finisher', {
+      instanceId: 'ally_finisher_inst',
+      startTime: 5,
+      hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+    });
+    const { result } = runArcaneScenario(allyFinisher);
+    const lasers = clusterLasers(result.simLog);
+    expect(lasers).toHaveLength(4);
+    expect(lasers.every(l => l.payload.actionId === 'ally_finisher_inst')).toBe(true);
+  });
+
+  it('does not apply finisher multiplier to cluster lasers triggered by a finisher', () => {
+    const allyFinisher = createAction('ally_finisher', 'finisher', {
+      instanceId: 'ally_finisher_inst',
+      startTime: 5,
+      hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+    });
+    const { result } = runArcaneScenario(allyFinisher, {
+      systemConstants: { finisherMultiplier: 1.75, tier: 'leader' },
+      initialEnemyState: {
+        stagger: {
+          value: 300,
+          maxStagger: 300,
+          breakRemaining: 20,
+          lockRemaining: 0,
+        },
+      },
+    });
+
+    const finisherHit = result.simLog.find(
+      entry =>
+        entry.type === 'DAMAGE_HIT' &&
+        entry.payload.actionId === 'ally_finisher_inst' &&
+        !entry.payload.hitData?.triggered,
+    );
+    expect(finisherHit?.type).toBe('DAMAGE_HIT');
+    if (finisherHit?.type === 'DAMAGE_HIT') {
+      expect(finisherHit.payload.hitData._finisherMult).toBeCloseTo(1.75, 5);
+    }
+
+    const lasers = clusterLasers(result.simLog);
+    expect(lasers).toHaveLength(4);
+    expect(lasers.every(l => Number(l.payload.hitData._finisherMult ?? 1) === 1)).toBe(true);
+  });
+
+  it('does not fire cluster lasers when ally basicAttack is not the final sequence hit', () => {
+    const allyMidCombo = createAction('ally_mid', 'basicAttack', {
+      instanceId: 'ally_mid_inst',
+      startTime: 5,
+      attackSequenceIndex: 2,
+      attackSequenceTotal: 5,
+      hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+    });
+    const { result } = runArcaneScenario(allyMidCombo);
+    expect(clusterLasers(result.simLog)).toHaveLength(0);
+  });
+
+  it('shows orange markers on Arcane ultimate when ally final strike triggers lasers', () => {
+    const allyFinal = createAction('ally_final', 'basicAttack', {
+      instanceId: 'ally_final_inst',
+      startTime: 5,
+      attackSequenceIndex: 5,
+      attackSequenceTotal: 5,
+      hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+    });
+    const { result } = runArcaneScenario(allyFinal);
+    const lasers = clusterLasers(result.simLog);
+    expect(lasers.length).toBeGreaterThan(0);
+
+    const trackStarts = [{ id: 'arcane_ult_inst', start: 0 }];
+    const actionMap = new Map([
+      ['arcane_ult_inst', { trackId: 'arcane' }],
+      ['ally_final_inst', { trackId: 'ally' }],
+    ]);
+
+    for (const laser of lasers) {
+      const hit = {
+        ...laser.payload.hitData,
+        actionId: laser.payload.actionId,
+        sourceId: laser.payload.sourceId,
+      };
+      expect(laser.payload.actionId).toBe('ally_final_inst');
+      expect(
+        actionItemShowsTriggeredHit(
+          'arcane_ult_inst',
+          'arcane',
+          trackStarts,
+          actionMap,
+          laser.time,
+          hit,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('shows orange markers on Arcane ultimate when ally finisher triggers lasers', () => {
+    const allyFinisher = createAction('ally_finisher', 'finisher', {
+      instanceId: 'ally_finisher_inst',
+      startTime: 5,
+      hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+    });
+    const { result } = runArcaneScenario(allyFinisher);
+    const lasers = clusterLasers(result.simLog);
+    const trackStarts = [{ id: 'arcane_ult_inst', start: 0 }];
+    const actionMap = new Map([
+      ['arcane_ult_inst', { trackId: 'arcane' }],
+      ['ally_finisher_inst', { trackId: 'ally' }],
+    ]);
+
+    for (const laser of lasers) {
+      expect(
+        actionItemShowsTriggeredHit(
+          'arcane_ult_inst',
+          'arcane',
+          trackStarts,
+          actionMap,
+          laser.time,
+          {
+            ...laser.payload.hitData,
+            actionId: laser.payload.actionId,
+            sourceId: laser.payload.sourceId,
+          },
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/simulation/arcaneImprisonmentSusceptibility.test.ts
+++ b/src/simulation/arcaneImprisonmentSusceptibility.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import arcaneSheet from '@/data/operators/arcane';
+import { applyForm } from '@/data/forms';
+import { collectTriggerEffects, patchCombatSkills } from '@/data/collect';
+import type { Action, ScenarioData, ScenarioTrack } from './compiler/types';
+import { compileScenario } from './compiler/compileScenario';
+import { simulate } from './simulator';
+import { TriggerRegistry } from './engine/TriggerRegistry';
+import { createDefaultStats } from '@/simulation/defaultActorStats';
+import { extractRawEntries, resolveHitsFromSheet } from '@/stores/timeline/resolveHits';
+import type { BaseStatValues } from '@/data/stats/types';
+import type { OperatorInstance, TeamInstance } from '@/types';
+
+const BASE_STATS: BaseStatValues = {
+  level: 60,
+  baseAtk: 1000,
+  baseHp: 1000,
+  weaponAtk: 0,
+  baseAttrs: {
+    strength: 100,
+    agility: 100,
+    intellect: 120,
+    will: 100,
+  },
+  mainAttributeName: 'intellect',
+  secondaryAttributeName: 'will',
+};
+
+function createAction(id: string, type: Action['type'], patch: Partial<Action> = {}): Action {
+  const startTime = Number(patch.startTime) || 0;
+  return {
+    id,
+    instanceId: patch.instanceId || `${id}_inst`,
+    type,
+    skillId: patch.skillId || id,
+    name: patch.name || id,
+    startTime,
+    logicalStartTime: patch.logicalStartTime ?? startTime,
+    cooldown: 0,
+    spCost: 0,
+    spGain: 0,
+    spGainKind: 'recover',
+    element: 'nature',
+    gaugeCost: 0,
+    gaugeGain: 0,
+    teamGaugeGain: 0,
+    enhancementTime: 0,
+    duration: 1,
+    triggerWindow: 0,
+    animationTime: 0,
+    isDisabled: false,
+    hits: [],
+    ...patch,
+  };
+}
+
+function createTrack(id: string, actions: Action[], patch: Partial<ScenarioTrack> = {}): ScenarioTrack {
+  const stats = { ...createDefaultStats(), ...(patch.stats || {}) } as ScenarioTrack['stats'];
+  return {
+    id,
+    actions,
+    stats,
+    baseStats: BASE_STATS,
+    gaugeEfficiency: 100,
+    originiumArtsPower: 0,
+    linkCdReduction: 0,
+    initialGauge: 0,
+    maxGaugeOverride: null,
+    acceptTeamGauge: true,
+    ...patch,
+  };
+}
+
+function resolveSkillHits(skillKey: 'comboSkill' | 'battleSkill', levelIndex = 11) {
+  const intFormSheet = applyForm(arcaneSheet, 'int');
+  const flatSkills = patchCombatSkills(intFormSheet, { talentStates: {}, potential: 0 });
+  const segment = flatSkills[skillKey]?.segments?.[0];
+  const rawEntries = extractRawEntries({ segments: [segment] }, 0);
+  return resolveHitsFromSheet([], rawEntries, levelIndex, { preserveCondition: true });
+}
+
+describe('Arcane battle skill vs combo susceptibility', () => {
+  it('clears combo susceptibility on detonate, then keeps the 2s grant through a later combo', () => {
+    const comboHits = resolveSkillHits('comboSkill');
+    const battleHits = resolveSkillHits('battleSkill');
+
+    const arcane = {
+      id: 'op_arcane',
+      operatorSlug: 'arcane',
+      level: 60,
+      promoted: true,
+      potential: 0,
+      skillLevels: { basicAttack: 12, battleSkill: 12, comboSkill: 12, ultimate: 12 },
+      talentStates: {},
+      trustLevel: 0,
+    } satisfies OperatorInstance;
+
+    const team: TeamInstance = {
+      id: 'team',
+      name: 't',
+      slots: [
+        {
+          operatorId: 'op_arcane',
+          weaponId: null,
+          gear: { armor: null, gloves: null, kit1: null, kit2: null },
+        },
+        { operatorId: null, weaponId: null, gear: { armor: null, gloves: null, kit1: null, kit2: null } },
+        { operatorId: null, weaponId: null, gear: { armor: null, gloves: null, kit1: null, kit2: null } },
+        { operatorId: null, weaponId: null, gear: { armor: null, gloves: null, kit1: null, kit2: null } },
+      ],
+    };
+
+    const collected = collectTriggerEffects(team, [arcane], [], [], new Map()).map(entry => ({
+      ...entry,
+      sourceTrackId: 'arcane',
+    }));
+
+    const tracks = [
+      createTrack('arcane', [
+        createAction('combo1', 'comboSkill', {
+          instanceId: 'combo1_inst',
+          startTime: 0,
+          duration: 1,
+          hits: comboHits.map(h => ({
+            ...h,
+            spRecovery: Number(h.spRecovery) || 0,
+            spReturn: Number(h.spReturn) || 0,
+            stagger: Number(h.stagger) || 0,
+          })) as any,
+        }),
+        createAction('battle', 'battleSkill', {
+          instanceId: 'battle_inst',
+          startTime: 1.2,
+          duration: 1,
+          hits: battleHits.map(h => ({
+            ...h,
+            offset: 0,
+            spRecovery: Number(h.spRecovery) || 0,
+            spReturn: Number(h.spReturn) || 0,
+            stagger: Number(h.stagger) || 0,
+          })) as any,
+        }),
+        // Second combo after detonate — must not cancel the 2s detonate susceptibility.
+        createAction('combo2', 'comboSkill', {
+          instanceId: 'combo2_inst',
+          startTime: 1.8,
+          duration: 1,
+          hits: comboHits.map(h => ({
+            ...h,
+            spRecovery: Number(h.spRecovery) || 0,
+            spReturn: Number(h.spReturn) || 0,
+            stagger: Number(h.stagger) || 0,
+          })) as any,
+        }),
+      ]),
+    ];
+
+    const { timeline, teamConfig, enemyConfig, actors } = compileScenario({
+      tracks,
+      connections: [],
+    } satisfies ScenarioData);
+
+    const result = simulate(
+      timeline,
+      teamConfig,
+      enemyConfig,
+      actors,
+      new TriggerRegistry(collected),
+      undefined,
+      { baseStatsByTrack: new Map([['arcane', BASE_STATS]]), enemyDef: 100 },
+    );
+
+    const comboSuscConsumes = result.enemyLog.filter(
+      e =>
+        e.type === 'ENEMY_EFFECT_EXPIRE' &&
+        e.kind === 'status' &&
+        e.id === 'arcane-combo-susceptibility' &&
+        e.consumed,
+    );
+    const detonateApplies = result.enemyLog.filter(
+      e => e.type === 'ENEMY_STATUS_APPLY' && e.id === 'arcane-combo-susceptibility-detonate',
+    );
+    const detonateNaturalExpires = result.enemyLog.filter(
+      e =>
+        e.type === 'ENEMY_EFFECT_EXPIRE' &&
+        e.kind === 'status' &&
+        e.id === 'arcane-combo-susceptibility-detonate' &&
+        !e.consumed,
+    );
+
+    expect(comboSuscConsumes.length).toBeGreaterThanOrEqual(1);
+    expect(detonateApplies.length).toBeGreaterThanOrEqual(1);
+
+    const detonate = detonateApplies[0]!;
+    // Later combo must not cancel the detonate timer.
+    expect(detonateNaturalExpires.some(e => Math.abs(e.time - detonate.expiresAt) < 0.05)).toBe(
+      true,
+    );
+  });
+});

--- a/src/simulation/compileEndaxisScenario.ts
+++ b/src/simulation/compileEndaxisScenario.ts
@@ -132,7 +132,7 @@ export function compileEndaxisScenario(input: CompileEndaxisScenarioInput) {
     runtimeInitialEffects = [],
     runtimeInitialEnemyState = null,
     simulationEndline = null,
-    lmdiAttributionMode = 'stacks',
+    lmdiAttributionMode = 'applier',
     controlledOperatorSegments = [],
   } = input;
 
@@ -156,17 +156,24 @@ export function compileEndaxisScenario(input: CompileEndaxisScenarioInput) {
         superArmor: Number(enemySheet?.superArmor ?? systemConstants?.superArmor) || 0,
         tier: enemySheet?.tier ?? 'normal',
         resistance: enemyResistance,
-        ...(enemySheet?.maxStagger !== undefined ? { maxStagger: enemySheet.maxStagger } : {}),
-        ...(enemySheet?.staggerNodeCount !== undefined
+        // Prefer UI/systemConstants edits; only fill from the preset sheet when absent.
+        ...(systemConstants?.maxStagger === undefined && enemySheet?.maxStagger !== undefined
+          ? { maxStagger: enemySheet.maxStagger }
+          : {}),
+        ...(systemConstants?.staggerNodeCount === undefined &&
+        enemySheet?.staggerNodeCount !== undefined
           ? { staggerNodeCount: enemySheet.staggerNodeCount }
           : {}),
-        ...(enemySheet?.staggerNodeDuration !== undefined
+        ...(systemConstants?.staggerNodeDuration === undefined &&
+        enemySheet?.staggerNodeDuration !== undefined
           ? { staggerNodeDuration: enemySheet.staggerNodeDuration }
           : {}),
-        ...(enemySheet?.staggerBreakDuration !== undefined
+        ...(systemConstants?.staggerBreakDuration === undefined &&
+        enemySheet?.staggerBreakDuration !== undefined
           ? { staggerBreakDuration: enemySheet.staggerBreakDuration }
           : {}),
-        ...(enemySheet?.finisherRecovery !== undefined
+        ...(systemConstants?.executionRecovery === undefined &&
+        enemySheet?.finisherRecovery !== undefined
           ? { executionRecovery: enemySheet.finisherRecovery }
           : {}),
       },

--- a/src/simulation/engine/SimulationContext.ts
+++ b/src/simulation/engine/SimulationContext.ts
@@ -20,8 +20,9 @@ export interface SimulationContext {
   /**
    * Drain matching queued events and run their handlers immediately (same `ctx`).
    * Used when a trigger phase must settle forced consumes before later same-frame conditions.
+   * Returns how many events were flushed.
    */
-  flushQueuedEvents: (predicate: (event: SimEvent) => boolean) => void;
+  flushQueuedEvents: (predicate: (event: SimEvent) => boolean) => number;
   simLog: (entry: SimLogEntry) => void;
   getAction: (id: string) => ResolvedAction | undefined;
   enemyLog: (event: EnemyStateEvent) => void;

--- a/src/simulation/engine/SimulationEngine.ts
+++ b/src/simulation/engine/SimulationEngine.ts
@@ -41,7 +41,7 @@ export class SimulationEngine {
   /** If set, simulation stops processing events beyond this time. */
   endlineTime?: number;
   /** LMDI attribution mode for reaction debuff contributions. */
-  lmdiAttributionMode: 'stacks' | 'applier' = 'stacks';
+  lmdiAttributionMode: 'stacks' | 'applier' = 'applier';
   /** Controlled-operator timeline (time-ascending segments). Empty = nobody controlled. */
   controlledOperatorSegments: ControlSegment[] = [];
   private enemyDamageCapWindows = new Map<number, number>();
@@ -335,6 +335,7 @@ export class SimulationEngine {
             throw new Error(`No handler for event type: ${event.type}`);
           }
         }
+        return events.length;
       },
       simLog: (entry: SimLogEntry) => {
         this.simLog.enqueue(entry);

--- a/src/simulation/events/HitHandler.ts
+++ b/src/simulation/events/HitHandler.ts
@@ -23,7 +23,6 @@ import {
   STAGGER_DAMAGE_MULTIPLIER,
 } from '@/data/stats/computeDamage';
 import type { ResolvedStatModifier } from '@/data/stats/types';
-import type { DamageElement } from '@/data/types';
 import {
   computeLmdiContributions,
   computeReactionLmdiContributions,
@@ -34,7 +33,12 @@ import {
   computeLevelCoefficient,
   computeArtsIntensityDamageMult,
 } from '@/data/stats/computeReactionDamage';
-import type { Effect, ResolvedEffect } from '@/data/types';
+import {
+  isEnemyEffect,
+  type DamageElement,
+  type Effect,
+  type ResolvedEffect,
+} from '@/data/types';
 
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
@@ -82,6 +86,17 @@ function afterDamageEffects(
 ): readonly (Effect | ResolvedEffect)[] | undefined {
   if (!effects?.length) return effects;
   return effects.filter(effect => effect.applyTiming !== 'beforeDamage');
+}
+
+function beforeDamageActorEffects(
+  effects: readonly (Effect | ResolvedEffect)[] | undefined,
+): readonly (Effect | ResolvedEffect)[] | undefined {
+  if (!effects?.length) return undefined;
+  // Enemy beforeDamage is scheduled in simulate(); only self/team here.
+  const matched = effects.filter(
+    effect => effect.applyTiming === 'beforeDamage' && !isEnemyEffect(effect),
+  );
+  return matched.length ? matched : undefined;
 }
 
 export class HitHandler implements EventHandler<HitEvent> {
@@ -135,6 +150,39 @@ export class HitHandler implements EventHandler<HitEvent> {
       }
     }
 
+    // Self/team beforeDamage effects must land before damage calc so this hit
+    // can benefit (enemy beforeDamage is scheduled earlier in simulate()).
+    const earlyActorEffects = beforeDamageActorEffects(hit.effects);
+    if (earlyActorEffects?.length) {
+      const sourceId = e.payload.sourceId ?? e.payload.actionId;
+      dispatchActorEffects(earlyActorEffects, {
+        time: e.time,
+        sourceTrackId: sourceId,
+        ctx,
+        enemySnap: ctx.state.enemy.statusSnapshot(),
+        skillType: hit.skillType,
+        skillId: hit.skillId,
+        actionId: e.payload.actionId,
+        statusActionId: e.payload.actionId,
+        spReason: 'hit',
+        applyCooldownReduction: this.registry
+          ? (eff, t, tid, c) => this.registry!.applyCooldownReduction(eff, t, tid, c)
+          : undefined,
+        onInstantHeal: this.registry
+          ? (id, stat, src, t, st) =>
+              this.registry!.onStatusApplied(id, stat, 'self', src, t, ctx, st, hit.skillId)
+          : undefined,
+      });
+      // Status applies are queued; settle them (and onStatusApplied follow-ups like
+      // conditional talent buffs) before reading operator mods for damage.
+      const isSameTimeOperatorEffect = (ev: { type: string; time: number }) =>
+        Number(ev.time) === Number(e.time) &&
+        (ev.type === 'OPERATOR_EFFECT_APPLY' || ev.type === 'OPERATOR_EFFECT_EXPIRE');
+      for (let i = 0; i < 8 && ctx.flushQueuedEvents(isSameTimeOperatorEffect) > 0; i++) {
+        /* cascade */
+      }
+    }
+
     // Compute expected damage using live operator + enemy state at time T
     const staggerMult = ctx.state.enemy.isBroken(e.time) ? STAGGER_DAMAGE_MULTIPLIER : 1;
     hit._staggerMult = staggerMult;
@@ -142,10 +190,13 @@ export class HitHandler implements EventHandler<HitEvent> {
       hit._staggerContributions = ctx.state.enemy.getStaggerContributionFractions();
     }
 
-    // Finisher multiplier: applies when a finisher action hits a staggered enemy
+    // Finisher multiplier: only the finisher action's own hits, not triggered follow-ups
+    // (e.g. Arcane cluster strike queued from onFinisher with the finisher's actionId).
     const action = ctx.getAction(e.payload.actionId);
     const finisherMult =
-      action?.node.type === 'finisher' && ctx.state.enemy.isBroken(e.time)
+      !hit.triggered &&
+      action?.node.type === 'finisher' &&
+      ctx.state.enemy.isBroken(e.time)
         ? (ctx.state.enemy.config.finisherMultiplier ?? 1)
         : 1;
     hit._finisherMult = finisherMult;
@@ -178,7 +229,9 @@ export class HitHandler implements EventHandler<HitEvent> {
       const operatorStatus = computeStats(baseStats, [], dynamicMods, undefined, hit.skillId);
 
       const enemyEntries = [...ctx.state.enemy.enemyStatusEffects.values()].filter(
-        entry => e.time < entry.expiresAt,
+        // Inclusive at expiresAt: same-timestamp derived hits (e.g. onStatusExpire
+        // damage) must still see sibling debuffs that share the expiry time.
+        entry => e.time <= entry.expiresAt,
       );
       const enemyMods: ResolvedStatModifier[] = [];
       for (const entry of enemyEntries) {
@@ -387,7 +440,9 @@ export class HitHandler implements EventHandler<HitEvent> {
       const operatorStatus = computeStats(baseStats, [], dynamicMods, hit.skillType, hit.skillId);
 
       const enemyEntries = [...ctx.state.enemy.enemyStatusEffects.values()].filter(
-        entry => e.time < entry.expiresAt,
+        // Inclusive at expiresAt: same-timestamp derived hits (e.g. onStatusExpire
+        // damage) must still see sibling debuffs that share the expiry time.
+        entry => e.time <= entry.expiresAt,
       );
       const enemyMods: ResolvedStatModifier[] = [];
       for (const entry of enemyEntries) {

--- a/src/simulation/events/effectDispatch.ts
+++ b/src/simulation/events/effectDispatch.ts
@@ -68,6 +68,20 @@ function getRuntimeEffectId(effect: Effect | ResolvedEffect): string {
   return raw.id ?? raw._id ?? raw.name ?? raw.kind ?? 'effect';
 }
 
+/**
+ * Enemy status map key. INDEPENDENT applications get a unique `@instance` suffix so a later
+ * grant does not cancel/overwrite an earlier one's duration (mirrors DoT cancelOnRefresh:false).
+ */
+export function resolveEnemyStatusInstanceId(
+  baseId: string,
+  stackStrategy: 'REFRESH_DURATION' | 'INDEPENDENT' | 'REPLACE' | undefined,
+  actionId: string | undefined,
+  time: number,
+): string {
+  if (stackStrategy !== 'INDEPENDENT') return baseId;
+  return `${baseId}@${actionId ?? time}`;
+}
+
 /** True if the condition (or any element of an array condition) has consume: true/number. */
 export function conditionHasConsume(
   cond: EffectCondition | EffectCondition[] | undefined,
@@ -858,7 +872,13 @@ export function dispatchEnemyEffects(
           );
         const { duration, stacks, maxStacks } = lifecycle;
         if (duration <= 0) break;
-        const effectId = getRuntimeEffectId(resolved);
+        const baseEffectId = getRuntimeEffectId(resolved);
+        const effectId = resolveEnemyStatusInstanceId(
+          baseEffectId,
+          lifecycle.stackStrategy,
+          actionId,
+          time,
+        );
         ctx.queue.enqueue(
           {
             type: 'ENEMY_EFFECT_APPLY',
@@ -879,7 +899,7 @@ export function dispatchEnemyEffects(
             actionId,
             icon: resolved.icon,
             effect: resolved,
-            ...(ctx.consumedStacksWriteKeys.has(effectId) && actionId
+            ...(ctx.consumedStacksWriteKeys.has(baseEffectId) && actionId
               ? { consumedStacks: ctx.getAction(actionId)?.consumedStacks }
               : {}),
             ...(resolved.silent ? { silent: true } : {}),

--- a/src/simulation/simulator.test.ts
+++ b/src/simulation/simulator.test.ts
@@ -557,6 +557,31 @@ describe('optimizer-native runtime parity', () => {
     expect(compiled?.consumedStacksWriteKeys.has('combo-state')).toBe(true);
     expect(compiled?.consumedStacksWriteKeys.has('vulnerability')).toBe(true);
     expect(compiled?.initialEffects).toBe(runtimeInitialEffects);
+
+    // Preset sheet defaults must not overwrite an explicit UI maxStagger edit.
+    const edited = compileEndaxisScenario({
+      scenarioData: createScenario(tracks),
+      tracks,
+      characterRoster: [
+        {
+          id: 'alpha',
+          element: 'heat',
+          accept_team_gauge: false,
+          accept_self_sp_cost_ult_energy: false,
+          maxUltimateGauge: 150,
+        },
+      ],
+      systemConstants: {
+        maxSp: 300,
+        initialSp: 123,
+        spRegenRate: 8,
+        skillSpCostDefault: 100,
+        maxStagger: 500,
+      },
+      prepDuration: 3,
+      activeEnemyId: 'eny_0051_rodin',
+    });
+    expect(edited?.enemyConfig.maxStagger).toBe(500);
     expect(compiled?.baseStatsByTrack.get('alpha')).toEqual(BASE_STATS);
     expect(compiled?.enemyDef).toBe(100);
     expect(compiled?.endlineTime).toBe(9);
@@ -3216,5 +3241,351 @@ describe('onFinisher trigger', () => {
 
   it('does not fire on a non-finisher action', () => {
     expect(fired('basicAttack')).toBe(false);
+  });
+});
+
+describe('beforeDamage self status', () => {
+  function hitDamage(applyTiming: 'beforeDamage' | 'afterDamage' | undefined) {
+    const tracks = [
+      createTrack('A', [
+        createAction('ult', 'ultimate', {
+          element: 'nature',
+          hits: [
+            {
+              offset: 0,
+              multiplier: 100,
+              spRecovery: 0,
+              spReturn: 0,
+              stagger: 0,
+              effects: [
+                {
+                  id: 'self-amp-buff',
+                  kind: 'status',
+                  target: 'self',
+                  stat: { modifier: 'ampBonus' },
+                  value: 50,
+                  duration: 10,
+                  ...(applyTiming ? { applyTiming } : {}),
+                },
+              ],
+            },
+          ],
+        }),
+      ]),
+    ];
+    return damageFor(runScenario(tracks), 'ult_inst');
+  }
+
+  it('lets the same hit benefit from a self buff applied beforeDamage', () => {
+    const after = hitDamage('afterDamage');
+    const before = hitDamage('beforeDamage');
+    expect(before / after).toBeCloseTo(1.5, 2);
+  });
+});
+
+describe('same-timestamp expire and triggered damage', () => {
+  it('lets onStatusExpire damage still see a sibling enemy debuff that expires at the same time', () => {
+    const triggerEffects = [
+      {
+        sourceTrackId: 'A',
+        triggerEffect: {
+          trigger: {
+            kind: 'onStatusExpire',
+            status: 'prison-marker',
+            target: 'enemy',
+          },
+          effects: [
+            {
+              kind: 'damageHit',
+              element: 'nature',
+              multiplier: 100,
+              hit: { stagger: 0 },
+            },
+          ],
+        },
+      },
+    ] satisfies TrackPatch['triggerEffects'];
+
+    const tracks = [
+      createTrack(
+        'A',
+        [
+          createAction('combo', 'comboSkill', {
+            element: 'nature',
+            startTime: 0,
+            hits: [
+              {
+                offset: 0,
+                multiplier: 1,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [
+                  {
+                    id: 'prison-marker',
+                    kind: 'status',
+                    target: 'enemy',
+                    duration: 1,
+                    applyTiming: 'beforeDamage',
+                  },
+                  {
+                    id: 'shared-vuln',
+                    kind: 'status',
+                    target: 'enemy',
+                    stat: { modifier: 'susceptibility', elements: ['nature'] },
+                    value: 50,
+                    duration: 1,
+                    applyTiming: 'beforeDamage',
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+        { triggerEffects },
+      ),
+    ];
+
+    const result = runScenario(tracks, registry(triggerEffects));
+    const explode = result.simLog.find(
+      item =>
+        item.type === 'DAMAGE_HIT' &&
+        item.payload.hitData?.triggered === true &&
+        item.payload.hitData?.element === 'nature',
+    );
+    expect(explode?.type).toBe('DAMAGE_HIT');
+    if (explode?.type !== 'DAMAGE_HIT') return;
+
+    const baselineTracks = [
+      createTrack('A', [
+        createAction('plain', 'comboSkill', {
+          element: 'nature',
+          hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+        }),
+      ]),
+    ];
+    const baseline = damageFor(runScenario(baselineTracks), 'plain_inst');
+    const exploded = Number(explode.payload.hitData._expectedDamage ?? 0);
+    expect(exploded / baseline).toBeCloseTo(1.5, 2);
+  });
+});
+
+describe('beforeDamage enemy status freeze extension', () => {
+  it('extends beforeDamage enemy status expiry across ultimate freeze (Arcane combo pattern)', () => {
+    const tracks = [
+      createTrack('A', [
+        createAction('combo', 'comboSkill', {
+          startTime: 0,
+          duration: 1,
+          element: 'nature',
+          hits: [
+            {
+              offset: 0.5,
+              multiplier: 10,
+              spRecovery: 0,
+              spReturn: 0,
+              stagger: 0,
+              effects: [
+                {
+                  id: 'prison-marker',
+                  kind: 'status',
+                  target: 'enemy',
+                  duration: 4,
+                  applyTiming: 'beforeDamage',
+                },
+                {
+                  id: 'combo-vuln',
+                  kind: 'status',
+                  target: 'enemy',
+                  stat: { modifier: 'susceptibility', elements: ['nature'] },
+                  value: 4,
+                  duration: 4,
+                  applyTiming: 'beforeDamage',
+                },
+              ],
+            },
+          ],
+        }),
+        createAction('ult', 'ultimate', {
+          startTime: 1,
+          duration: 2,
+          animationTime: 2,
+          enhancementTime: 0,
+          element: 'nature',
+          hits: [{ offset: 0.5, multiplier: 10, spRecovery: 0, spReturn: 0, stagger: 0 }],
+        }),
+      ]),
+    ];
+
+    const result = runScenario(tracks);
+    const applies = result.enemyLog.filter(
+      e =>
+        e.type === 'ENEMY_STATUS_APPLY' &&
+        (e.id === 'prison-marker' || e.id === 'combo-vuln'),
+    );
+    expect(applies).toHaveLength(2);
+
+    // Combo hit at realTime ~0.5; without freeze expiry would be ~4.5.
+    // Ultimate freeze [1, 3] overlaps the remaining duration → expiry should be pushed by 2s.
+    for (const apply of applies) {
+      expect(apply.expiresAt).toBeGreaterThan(6);
+      expect(apply.expiresAt).toBeCloseTo(6.5, 1);
+    }
+  });
+
+  it('keeps afterDamage enemy status freeze extension working (control)', () => {
+    const tracks = [
+      createTrack('A', [
+        createAction('combo', 'comboSkill', {
+          startTime: 0,
+          duration: 1,
+          element: 'nature',
+          hits: [
+            {
+              offset: 0.5,
+              multiplier: 10,
+              spRecovery: 0,
+              spReturn: 0,
+              stagger: 0,
+              effects: [
+                {
+                  id: 'after-vuln',
+                  kind: 'status',
+                  target: 'enemy',
+                  stat: { modifier: 'susceptibility', elements: ['nature'] },
+                  value: 4,
+                  duration: 4,
+                },
+              ],
+            },
+          ],
+        }),
+        createAction('ult', 'ultimate', {
+          startTime: 1,
+          duration: 2,
+          animationTime: 2,
+          enhancementTime: 0,
+          element: 'nature',
+          hits: [{ offset: 0.5, multiplier: 10, spRecovery: 0, spReturn: 0, stagger: 0 }],
+        }),
+      ]),
+    ];
+
+    const result = runScenario(tracks);
+    const apply = result.enemyLog.find(
+      e => e.type === 'ENEMY_STATUS_APPLY' && e.id === 'after-vuln',
+    );
+    expect(apply?.type).toBe('ENEMY_STATUS_APPLY');
+    if (apply?.type !== 'ENEMY_STATUS_APPLY') return;
+    expect(apply.expiresAt).toBeGreaterThan(6);
+    expect(apply.expiresAt).toBeCloseTo(6.5, 1);
+  });
+});
+
+describe('independent enemy status instance ids', () => {
+  it('keeps an earlier INDEPENDENT status timer when a later grant reuses the same base id', () => {
+    // Engine regression for resolveEnemyStatusInstanceId — not Arcane-specific.
+    const triggerEffects = [
+      {
+        sourceTrackId: 'A',
+        triggerEffect: {
+          trigger: { kind: 'onHit', skillTypes: 'battleSkill' },
+          effects: [
+            {
+              id: 'shared-vuln',
+              kind: 'status',
+              target: 'enemy',
+              stat: { modifier: 'susceptibility', elements: ['nature'] },
+              value: 10,
+              duration: 2,
+              stackStrategy: 'INDEPENDENT',
+            },
+          ],
+        },
+      },
+    ] satisfies TrackPatch['triggerEffects'];
+
+    const tracks = [
+      createTrack(
+        'A',
+        [
+          createAction('battle', 'battleSkill', {
+            startTime: 0,
+            duration: 0.5,
+            element: 'nature',
+            hits: [{ offset: 0, multiplier: 1, spRecovery: 0, spReturn: 0, stagger: 0 }],
+          }),
+          createAction('combo', 'comboSkill', {
+            startTime: 0.5,
+            duration: 1,
+            element: 'nature',
+            hits: [
+              {
+                offset: 0,
+                multiplier: 1,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [
+                  {
+                    id: 'shared-vuln',
+                    kind: 'status',
+                    target: 'enemy',
+                    stat: { modifier: 'susceptibility', elements: ['nature'] },
+                    value: 10,
+                    duration: 4,
+                    applyTiming: 'beforeDamage',
+                    stackStrategy: 'INDEPENDENT',
+                  },
+                ],
+              },
+            ],
+          }),
+          createAction('probe', 'basicAttack', {
+            startTime: 1.5,
+            duration: 0.5,
+            element: 'nature',
+            hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+          }),
+        ],
+        { triggerEffects },
+      ),
+    ];
+
+    const result = runScenario(tracks, registry(triggerEffects));
+    const applies = result.enemyLog.filter(
+      e => e.type === 'ENEMY_STATUS_APPLY' && String(e.id).startsWith('shared-vuln'),
+    );
+    expect(applies).toHaveLength(2);
+    expect(new Set(applies.map(e => e.id)).size).toBe(2);
+
+    const first = applies[0]!;
+    const second = applies[1]!;
+    // Battle-skill grant (~2s) then combo grant (~4s); exact expiry can shift with freeze.
+    expect(first.expiresAt).toBeLessThan(second.expiresAt);
+    expect(second.expiresAt - second.time).toBeGreaterThan(3);
+
+    // First expiry must still fire (was previously cancelled by the second grant).
+    const firstExpire = result.enemyLog.find(
+      e =>
+        e.type === 'ENEMY_EFFECT_EXPIRE' &&
+        e.kind === 'status' &&
+        e.id === first.id &&
+        !e.consumed,
+    );
+    expect(firstExpire?.time).toBeCloseTo(first.expiresAt, 1);
+
+    // While both are active, nature susceptibility should stack (10% + 10%).
+    const baselineTracks = [
+      createTrack('A', [
+        createAction('probe', 'basicAttack', {
+          element: 'nature',
+          hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+        }),
+      ]),
+    ];
+    const baseline = damageFor(runScenario(baselineTracks), 'probe_inst');
+    const stacked = damageFor(result, 'probe_inst');
+    expect(stacked / baseline).toBeCloseTo(1.2, 2);
   });
 });

--- a/src/simulation/simulator.ts
+++ b/src/simulation/simulator.ts
@@ -10,6 +10,7 @@ import type { TriggerRegistry } from './engine/TriggerRegistry';
 import type { Effect, OperatorStat, ResolvedEffect } from '@/data/types';
 import { isEnemyEffect } from '@/data/types';
 import { resolveEffectDefaults, resolveEffectLifecycle } from '@/data/effectPresets';
+import { resolveEnemyStatusInstanceId } from '@/simulation/events/effectDispatch';
 import type { EnemyEffectApplyEvent } from '@/simulation/engine/types';
 import type { BaseStatValues } from '@/data/stats/types';
 import type { EnemyResistance } from '@/data/enemyResistance';
@@ -57,6 +58,7 @@ function buildBeforeDamageEnemyEffectEvents(
   actionId: string,
   skillType?: string,
   skillId?: string,
+  getShiftedTime?: (startTime: number, duration: number) => number,
 ): EnemyEffectApplyEvent[] {
   if (!effects?.length) return [];
   const events: EnemyEffectApplyEvent[] = [];
@@ -109,22 +111,30 @@ function buildBeforeDamageEnemyEffectEvents(
           forced: true,
         });
         break;
-      case 'status':
+      case 'status': {
+        const duration = lifecycle.duration;
+        const expiresAt =
+          resolved.ignoreTimeShift || !getShiftedTime
+            ? time + duration
+            : getShiftedTime(time, duration);
+        const baseId = resolved.id || resolved.name || 'status';
         events.push({
           ...base,
           kind: 'status',
-          id: resolved.id || resolved.name || 'status',
+          id: resolveEnemyStatusInstanceId(baseId, lifecycle.stackStrategy, actionId, time),
           stat: resolved.stat as any,
           value: typeof resolved.value === 'number' ? resolved.value : 0,
           stacks: typeof lifecycle.stacks === 'number' ? lifecycle.stacks : 1,
           maxStacks: lifecycle.maxStacks,
-          expiresAt: time + lifecycle.duration,
+          expiresAt,
+          stackStrategy: lifecycle.stackStrategy,
           icon: Array.isArray(resolved.icon) ? resolved.icon[0] : resolved.icon,
           effect: resolved,
           silent: resolved.silent,
           external: resolved.external,
         });
         break;
+      }
     }
   }
 
@@ -636,6 +646,7 @@ export function simulate(
         action.id,
         hit.skillType,
         hit.skillId,
+        (start, duration) => engine.getShiftedTime(start, duration),
       )) {
         engine.enqueue(event, -1);
       }

--- a/src/stores/timelineStore.ts
+++ b/src/stores/timelineStore.ts
@@ -667,7 +667,7 @@ export const useTimelineStore = defineStore('timeline', () => {
   const simulationStartline = ref<number | null>(null);
   const isEndlineSelected = ref(false);
   const isStartlineSelected = ref(false);
-  const lmdiAttributionMode = ref<'stacks' | 'applier'>('stacks');
+  const lmdiAttributionMode = ref<'stacks' | 'applier'>('applier');
 
   const connectionMap = computed(() => {
     const map = new Map();


### PR DESCRIPTION
## Summary
- **阵诀智**：破晦阵/腐蚀 `beforeDamage` 使本击吃到天赋放大；囹圄引爆清除连携脆弱并用独立 id 施加 2s 脆弱（后续连携不取消）；集束打击归属与终结技倍率修正；状态绑定强化时间只读展示。
- **装备**：长息 `dmgBonus` 改为全元素作用域，异常/爆发可吃到；动火用腐蚀图标路径修正。
- **模拟/分析**：预设敌人失衡上限等以 UI 编辑为准，不再每次编译被 sheet 覆盖；干员贡献默认「按施加者」；敌方 `INDEPENDENT` 状态支持实例化 id。
- **测试**：补充集束打击、囹圄脆弱与相关 simulator 回归。

## Test plan
- [ ] 阵诀智：连携上囹圄+脆弱 → 战技引爆 → 确认连携脆弱被清、出现 2s 脆弱；再放连携，2s 脆弱继续走完
- [ ] 阵诀智：大破晦阵命中应吃到天赋 1 放大；集束打击橙色判定点出现在诀轨道，且终结技触发的激光无终结技倍率
- [ ] 长息：队伍队友触发腐蚀/爆发时，队友伤害应吃到 +16% 伤害加成
- [ ] 预设敌人：改失衡上限后重新演算，应在新上限才进入失衡
- [ ] 伤害分析：打开后干员贡献默认选中「按施加者」

Made with [Cursor](https://cursor.com)