### PR TITLE
Fix : 统一命中附带脆弱等 debuff 在伤害前生效

### DIFF
--- a/src/data/operators/antal.ts
+++ b/src/data/operators/antal.ts
@@ -238,6 +238,7 @@ const sheet: OperatorSheet = {
                       stat: { modifier: 'susceptibility', elements: ['electric', 'heat'] },
                       value: [5, 5, 6, 6, 7, 7, 8, 8, 8, 9, 9, 10],
                       duration: 60,
+                      applyTiming: 'beforeDamage',
                       icon: '/operators/antal/icon_battle_antal_buff.webp',
                     },
                   ],

--- a/src/data/operators/ardelia.ts
+++ b/src/data/operators/ardelia.ts
@@ -191,6 +191,7 @@ const sheet: OperatorSheet = {
                       stat: { modifier: 'susceptibility', elements: 'physical' },
                       value: [12, 12, 12, 13, 13, 13, 14, 14, 16, 17, 18, 20],
                       duration: 30,
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'enemyStatus',
                         status: 'corrosion',
@@ -206,6 +207,7 @@ const sheet: OperatorSheet = {
                       },
                       value: [12, 12, 12, 13, 13, 13, 14, 14, 16, 17, 18, 20],
                       duration: 30,
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'enemyStatus',
                         status: 'corrosion',

--- a/src/data/operators/avywenna.ts
+++ b/src/data/operators/avywenna.ts
@@ -85,6 +85,7 @@ const sheet: OperatorSheet = {
                 stat: { modifier: 'susceptibility', elements: 'electric' },
                 value: [6, 10],
                 duration: 10,
+                applyTiming: 'beforeDamage',
               },
             ],
           },

--- a/src/data/operators/camille.ts
+++ b/src/data/operators/camille.ts
@@ -320,6 +320,7 @@ const sheet: OperatorSheet = {
                       stat: { modifier: 'susceptibility', elements: 'heat' },
                       value: [5, 5, 5, 6, 6, 6, 6, 6, 6, 6.5, 6.5, 7],
                       duration: 45,
+                      applyTiming: 'beforeDamage',
                     },
                     {
                       id: 'camille-firefang-vesperwings-weaken',
@@ -329,6 +330,7 @@ const sheet: OperatorSheet = {
                       value: [5, 5, 5, 6, 6, 6, 6, 6, 6, 6.5, 6.5, 7],
                       duration: 45,
                       hide: true,
+                      applyTiming: 'beforeDamage',
                     },
                   ],
                 },

--- a/src/data/operators/catcher.ts
+++ b/src/data/operators/catcher.ts
@@ -288,7 +288,13 @@ const sheet: OperatorSheet = {
                   offset: 1.53,
                   stagger: 5,
                   effects: [
-                    { kind: 'status', stat: { modifier: 'weaken' }, target: 'enemy', duration: 8 },
+                    {
+                      kind: 'status',
+                      stat: { modifier: 'weaken' },
+                      target: 'enemy',
+                      duration: 8,
+                      applyTiming: 'beforeDamage',
+                    },
                   ],
                 },
               ],

--- a/src/data/operators/estella.ts
+++ b/src/data/operators/estella.ts
@@ -278,6 +278,7 @@ const sheet: OperatorSheet = {
                       stat: { modifier: 'susceptibility', elements: 'physical' },
                       value: [10, 10, 10, 10, 10, 10, 10, 10, 10, 15, 15, 15],
                       duration: 6,
+                      applyTiming: 'beforeDamage',
                     },
                   ],
                 },

--- a/src/data/operators/gilberta.ts
+++ b/src/data/operators/gilberta.ts
@@ -296,6 +296,7 @@ const sheet: OperatorSheet = {
                         ],
                       },
                       duration: 5,
+                      applyTiming: 'beforeDamage',
                     },
                     {
                       kind: 'status',

--- a/src/data/operators/lifeng.ts
+++ b/src/data/operators/lifeng.ts
@@ -271,6 +271,7 @@ const sheet: OperatorSheet = {
                       stat: { modifier: 'susceptibility', elements: 'physical' },
                       value: [5, 5, 5, 5, 5, 7, 7, 7, 9, 10, 10, 12],
                       duration: 12,
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'not',
                         condition: { kind: 'enemyStatus', status: 'vulnerability' },

--- a/src/data/operators/mifu.ts
+++ b/src/data/operators/mifu.ts
@@ -368,6 +368,7 @@ const sheet: OperatorSheet = {
                       stat: { modifier: 'susceptibility', elements: 'physical' },
                       value: 5,
                       duration: 16,
+                      applyTiming: 'beforeDamage',
                     },
                   ],
                 },

--- a/src/data/operators/tangtang.ts
+++ b/src/data/operators/tangtang.ts
@@ -91,6 +91,7 @@ const sheet: OperatorSheet = {
                 ],
               },
               duration: 15,
+              applyTiming: 'beforeDamage',
               condition: {
                 kind: 'operatorStatus',
                 status: 'tangtang-whirlpools',
@@ -408,6 +409,7 @@ const sheet: OperatorSheet = {
                         ],
                       },
                       duration: 15,
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'operatorStatus',
                         status: 'tangtang-whirlpools',

--- a/src/data/operators/xaihi.ts
+++ b/src/data/operators/xaihi.ts
@@ -36,6 +36,7 @@ const sheet: OperatorSheet = {
                   status: ['cryoInfliction', 'solidification'],
                 },
                 duration: 5,
+                applyTiming: 'beforeDamage',
               },
             ],
           },

--- a/src/simulation/events/HitHandler.ts
+++ b/src/simulation/events/HitHandler.ts
@@ -92,9 +92,19 @@ function beforeDamageActorEffects(
   effects: readonly (Effect | ResolvedEffect)[] | undefined,
 ): readonly (Effect | ResolvedEffect)[] | undefined {
   if (!effects?.length) return undefined;
-  // Enemy beforeDamage is scheduled in simulate(); only self/team here.
   const matched = effects.filter(
     effect => effect.applyTiming === 'beforeDamage' && !isEnemyEffect(effect),
+  );
+  return matched.length ? matched : undefined;
+}
+
+function beforeDamageEnemyEffects(
+  effects: readonly (Effect | ResolvedEffect)[] | undefined,
+): readonly (Effect | ResolvedEffect)[] | undefined {
+  if (!effects?.length) return undefined;
+  // Applied here (not pre-scheduled) so conditions/consume see live state.
+  const matched = effects.filter(
+    effect => effect.applyTiming === 'beforeDamage' && isEnemyEffect(effect),
   );
   return matched.length ? matched : undefined;
 }
@@ -150,14 +160,15 @@ export class HitHandler implements EventHandler<HitEvent> {
       }
     }
 
-    // Self/team beforeDamage effects must land before damage calc so this hit
-    // can benefit (enemy beforeDamage is scheduled earlier in simulate()).
+    // beforeDamage effects must land before damage calc so this hit can benefit.
+    // Enemy effects are applied here (not pre-scheduled) so conditions/consume
+    // evaluate against live state (e.g. Tangtang whirlpools, Ardelia corrosion).
+    const sourceIdForEarly = e.payload.sourceId ?? e.payload.actionId;
     const earlyActorEffects = beforeDamageActorEffects(hit.effects);
     if (earlyActorEffects?.length) {
-      const sourceId = e.payload.sourceId ?? e.payload.actionId;
       dispatchActorEffects(earlyActorEffects, {
         time: e.time,
-        sourceTrackId: sourceId,
+        sourceTrackId: sourceIdForEarly,
         ctx,
         enemySnap: ctx.state.enemy.statusSnapshot(),
         skillType: hit.skillType,
@@ -173,12 +184,35 @@ export class HitHandler implements EventHandler<HitEvent> {
               this.registry!.onStatusApplied(id, stat, 'self', src, t, ctx, st, hit.skillId)
           : undefined,
       });
-      // Status applies are queued; settle them (and onStatusApplied follow-ups like
-      // conditional talent buffs) before reading operator mods for damage.
-      const isSameTimeOperatorEffect = (ev: { type: string; time: number }) =>
+    }
+    const earlyEnemyEffects = beforeDamageEnemyEffects(hit.effects);
+    if (earlyEnemyEffects?.length) {
+      dispatchEnemyEffects(
+        earlyEnemyEffects,
+        e.time,
+        sourceIdForEarly,
+        ctx,
+        hit.skillType,
+        e.payload.actionId,
+        undefined,
+        ctx.state.enemy.statusSnapshot(),
+        hit.skillId,
+      );
+    }
+    if (earlyActorEffects?.length || earlyEnemyEffects?.length) {
+      // Settle applies (and onStatusApplied follow-ups) before reading mods for damage.
+      // Skip consumed expires so stack scaling still sees pre-consume state.
+      const isSameTimeEffectApply = (ev: {
+        type: string;
+        time: number;
+        consumed?: boolean;
+      }) =>
         Number(ev.time) === Number(e.time) &&
-        (ev.type === 'OPERATOR_EFFECT_APPLY' || ev.type === 'OPERATOR_EFFECT_EXPIRE');
-      for (let i = 0; i < 8 && ctx.flushQueuedEvents(isSameTimeOperatorEffect) > 0; i++) {
+        (ev.type === 'OPERATOR_EFFECT_APPLY' ||
+          ev.type === 'ENEMY_EFFECT_APPLY' ||
+          ((ev.type === 'OPERATOR_EFFECT_EXPIRE' || ev.type === 'ENEMY_EFFECT_EXPIRE') &&
+            !ev.consumed));
+      for (let i = 0; i < 8 && ctx.flushQueuedEvents(isSameTimeEffectApply) > 0; i++) {
         /* cascade */
       }
     }

--- a/src/simulation/simulator.test.ts
+++ b/src/simulation/simulator.test.ts
@@ -3502,6 +3502,126 @@ describe('beforeDamage enemy status freeze extension', () => {
     expect((apply as { value?: number } | undefined)?.value).toBeCloseTo(5.25, 5);
   });
 
+  it('lets the same hit benefit from beforeDamage enemy susceptibility', () => {
+    function hitDamage(applyTiming: 'beforeDamage' | 'afterDamage') {
+      const tracks = [
+        createTrack('A', [
+          createAction('skill', 'battleSkill', {
+            startTime: 0,
+            duration: 1,
+            element: 'nature',
+            hits: [
+              {
+                offset: 0.5,
+                multiplier: 100,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [
+                  {
+                    id: 'hit-vuln',
+                    kind: 'status',
+                    target: 'enemy',
+                    stat: { modifier: 'susceptibility', elements: ['nature'] },
+                    value: 50,
+                    duration: 10,
+                    applyTiming,
+                  },
+                ],
+              },
+            ],
+          }),
+        ]),
+      ];
+      return damageFor(runScenario(tracks), 'skill_inst');
+    }
+    const after = hitDamage('afterDamage');
+    const before = hitDamage('beforeDamage');
+    expect(before / after).toBeCloseTo(1.5, 2);
+  });
+
+  it('evaluates conditions for beforeDamage enemy status (Tangtang / Ardelia pattern)', () => {
+    function run(withWhirlpools: boolean) {
+      const tracks = [
+        createTrack('A', [
+          createAction('skill', 'battleSkill', {
+            startTime: 0,
+            duration: 1,
+            element: 'nature',
+            hits: [
+              {
+                offset: 0.5,
+                multiplier: 100,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [
+                  {
+                    id: 'cond-vuln',
+                    kind: 'status',
+                    target: 'enemy',
+                    stat: { modifier: 'susceptibility', elements: ['nature'] },
+                    value: 0,
+                    duration: 10,
+                    applyTiming: 'beforeDamage',
+                    scaling: {
+                      additive: [
+                        { key: 'whirlpools', target: 'self', coefficient: 5 },
+                      ],
+                    },
+                    condition: {
+                      kind: 'operatorStatus',
+                      status: 'whirlpools',
+                      consume: true,
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+        ]),
+      ];
+      const { timeline, teamConfig, enemyConfig, actors } = compileScenario(createScenario(tracks));
+      const baseStatsByTrack = new Map<string, BaseStatValues>(
+        actors.map(actor => [actor.id, BASE_STATS]),
+      );
+      return simulate(timeline, teamConfig, enemyConfig, actors, undefined, undefined, {
+        baseStatsByTrack,
+        enemyDef: 100,
+        initialEffects: withWhirlpools
+          ? [
+              {
+                targetTrackId: 'A',
+                id: 'whirlpools',
+                value: 0,
+                stacks: 3,
+                maxStacks: 3,
+                remainingDuration: 30,
+                sourceId: 'A',
+              },
+            ]
+          : [],
+      });
+    }
+
+    const without = run(false);
+    expect(
+      without.enemyLog.some(e => e.type === 'ENEMY_STATUS_APPLY' && e.id === 'cond-vuln'),
+    ).toBe(false);
+
+    const withStacks = run(true);
+    const apply = withStacks.enemyLog.find(
+      e => e.type === 'ENEMY_STATUS_APPLY' && e.id === 'cond-vuln',
+    );
+    expect(apply).toBeTruthy();
+    // 0 + 3 stacks * 5 = 15
+    expect((apply as { value?: number } | undefined)?.value).toBeCloseTo(15, 5);
+    // Same hit should see the vuln (beforeDamage)
+    const dmg = damageFor(withStacks, 'skill_inst');
+    const baseline = damageFor(run(false), 'skill_inst');
+    expect(dmg / baseline).toBeCloseTo(1.15, 2);
+  });
+
   it('extends beforeDamage enemy status expiry across ultimate freeze (Arcane combo pattern)', () => {
     const tracks = [
       createTrack('A', [

--- a/src/simulation/simulator.ts
+++ b/src/simulation/simulator.ts
@@ -7,11 +7,7 @@ import {
   getReactionMultiplier,
 } from '@/data/stats/computeReactionDamage';
 import type { TriggerRegistry } from './engine/TriggerRegistry';
-import type { Effect, OperatorStat, ResolvedEffect } from '@/data/types';
-import { isEnemyEffect } from '@/data/types';
-import { resolveEffectDefaults, resolveEffectLifecycle } from '@/data/effectPresets';
-import { resolveEnemyStatusInstanceId } from '@/simulation/events/effectDispatch';
-import type { EnemyEffectApplyEvent } from '@/simulation/engine/types';
+import type { OperatorStat } from '@/data/types';
 import type { BaseStatValues } from '@/data/stats/types';
 import type { EnemyResistance } from '@/data/enemyResistance';
 import { normalizeEnemyResistance } from '@/data/enemyResistance';
@@ -47,98 +43,6 @@ interface SimulationOptions {
   endlineTime?: number;
   lmdiAttributionMode?: 'stacks' | 'applier';
   controlledOperatorSegments?: ControlSegment[];
-}
-
-const BEFORE_DAMAGE_EPSILON = 1e-6;
-
-function buildBeforeDamageEnemyEffectEvents(
-  effects: readonly (Effect | ResolvedEffect)[] | undefined,
-  time: number,
-  sourceId: string,
-  actionId: string,
-  skillType?: string,
-  skillId?: string,
-  getShiftedTime?: (startTime: number, duration: number) => number,
-): EnemyEffectApplyEvent[] {
-  if (!effects?.length) return [];
-  const events: EnemyEffectApplyEvent[] = [];
-
-  for (const effect of effects) {
-    if (effect.applyTiming !== 'beforeDamage') continue;
-    if (!isEnemyEffect(effect)) continue;
-
-    const resolved = resolveEffectDefaults(effect as any) as Effect | ResolvedEffect;
-    const lifecycle = resolveEffectLifecycle(resolved);
-    const base = {
-      type: 'ENEMY_EFFECT_APPLY' as const,
-      time,
-      sourceId,
-      sourceSkillType: skillType,
-      sourceSkillId: skillId,
-      actionId,
-    };
-
-    switch (resolved.kind) {
-      case 'infliction':
-        events.push({
-          ...base,
-          kind: 'infliction',
-          element: resolved.element,
-          stacks: lifecycle.stacks,
-          effectiveDuration: lifecycle.duration,
-        });
-        break;
-      case 'physicalStatus':
-        events.push({
-          ...base,
-          kind: 'physicalStatus',
-          physicalType: resolved.physicalType,
-          forced: resolved.forced,
-          effectiveness:
-            typeof resolved.effectiveness === 'number' ? resolved.effectiveness : undefined,
-          effectiveDuration: lifecycle.duration,
-        });
-        break;
-      case 'reaction':
-        events.push({
-          ...base,
-          kind: 'reaction',
-          reactionType: resolved.reactionType as any,
-          level: resolved.defaultLevel ?? 1,
-          requiresInfliction: resolved.requiresInfliction,
-          effectiveness: resolved.effectiveness,
-          effectiveDuration: lifecycle.duration,
-          forced: true,
-        });
-        break;
-      case 'status': {
-        const duration = lifecycle.duration;
-        const expiresAt =
-          resolved.ignoreTimeShift || !getShiftedTime
-            ? time + duration
-            : getShiftedTime(time, duration);
-        const baseId = resolved.id || resolved.name || 'status';
-        events.push({
-          ...base,
-          kind: 'status',
-          id: resolveEnemyStatusInstanceId(baseId, lifecycle.stackStrategy, actionId, time),
-          stat: resolved.stat as any,
-          value: typeof resolved.value === 'number' ? resolved.value : 0,
-          stacks: typeof lifecycle.stacks === 'number' ? lifecycle.stacks : 1,
-          maxStacks: lifecycle.maxStacks,
-          expiresAt,
-          stackStrategy: lifecycle.stackStrategy,
-          icon: Array.isArray(resolved.icon) ? resolved.icon[0] : resolved.icon,
-          effect: resolved,
-          silent: resolved.silent,
-          external: resolved.external,
-        });
-        break;
-      }
-    }
-  }
-
-  return events;
 }
 
 export function simulate(
@@ -639,18 +543,6 @@ export function simulate(
     }
 
     action.resolvedHits.forEach(hit => {
-      for (const event of buildBeforeDamageEnemyEffectEvents(
-        hit.effects,
-        Math.max(0, hit.realTime - BEFORE_DAMAGE_EPSILON),
-        action.trackId,
-        action.id,
-        hit.skillType,
-        hit.skillId,
-        (start, duration) => engine.getShiftedTime(start, duration),
-      )) {
-        engine.enqueue(event, -1);
-      }
-
       engine.enqueue({
         type: 'DAMAGE_HIT',
         time: hit.realTime,


### PR DESCRIPTION
- 命中上影响本 hit 伤害的敌人 debuff（脆弱/削弱/易伤等）统一为 ``applyTiming: beforeDamage``
- 敌人 beforeDamage 改为在 HitHandler 伤害结算前应用，以正确处理条件与 consume（避免预调度跳过条件）
- 补充 beforeDamage 同 hit 受益、条件+层数缩放等回归测试