### PR TITLE
Fix: hit 附着伤害前结算，并修复伊冯冰点与终结技额外伤害

### DIFF
--- a/src/data/operators/akekuri.ts
+++ b/src/data/operators/akekuri.ts
@@ -206,6 +206,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'heat',
+                      applyTiming: 'beforeDamage',
                     },
                   ],
                 },

--- a/src/data/operators/alesh.ts
+++ b/src/data/operators/alesh.ts
@@ -399,7 +399,7 @@ const sheet: OperatorSheet = {
                   offset: 3,
                   spRecovery: [20, 20, 20, 20, 20, 20, 20, 20, 20, 25, 25, 25],
                   stagger: 20,
-                  effects: [{ kind: 'infliction', element: 'cryo' }],
+                  effects: [{ kind: 'infliction', element: 'cryo', applyTiming: 'beforeDamage' }],
                 },
               ],
             },

--- a/src/data/operators/antal.ts
+++ b/src/data/operators/antal.ts
@@ -38,6 +38,7 @@ const COMBO_SKILL_EFFECTS: Effect[] = [...INFLICTIONS, ...PHYSICAL_REACTIONS].ma
     ? {
         kind: 'infliction' as const,
         element: x as ArtsElement,
+        applyTiming: 'beforeDamage' as const,
       }
     : {
         kind: 'physicalStatus' as const,

--- a/src/data/operators/arcane.ts
+++ b/src/data/operators/arcane.ts
@@ -33,6 +33,7 @@ const INFLICTION_TRACKER: TriggerEffect[] = INFLICTIONS.map(x => ({
 const COMBO_SKILL_EFFECTS: Effect[] = INFLICTIONS.map(x => ({
   kind: 'infliction' as const,
   element: x as ArtsElement,
+  applyTiming: 'beforeDamage' as const,
   condition: {
     kind: 'operatorStatus',
     status: TRACKER_IDS[x]!,
@@ -950,6 +951,7 @@ const sheet: OperatorSheet = {
                             (element: ArtsElement) => ({
                               kind: 'infliction' as const,
                               element,
+                              applyTiming: 'beforeDamage' as const,
                               condition: {
                                 kind: 'enemyStatus' as const,
                                 status: `${element}Infliction` as const,

--- a/src/data/operators/arclight.ts
+++ b/src/data/operators/arclight.ts
@@ -327,7 +327,7 @@ const sheet: OperatorSheet = {
                 {
                   offset: 2.03,
                   stagger: [7, 7, 7, 7, 7, 7, 7, 7, 7, 10, 10, 10],
-                  effects: [{ kind: 'infliction', element: 'electric' }],
+                  effects: [{ kind: 'infliction', element: 'electric', applyTiming: 'beforeDamage' }],
                 },
               ],
             },

--- a/src/data/operators/avywenna.ts
+++ b/src/data/operators/avywenna.ts
@@ -357,6 +357,7 @@ const sheet: OperatorSheet = {
                       kind: 'infliction',
                       element: 'electric',
                       stacks: 'fromConsume',
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'operatorStatus',
                         status: 'avywenna-thunderlance-ex',

--- a/src/data/operators/camille.ts
+++ b/src/data/operators/camille.ts
@@ -311,7 +311,7 @@ const sheet: OperatorSheet = {
                   offset: 0.467,
                   stagger: 10,
                   effects: [
-                    { kind: 'infliction', element: 'heat' },
+                    { kind: 'infliction', element: 'heat', applyTiming: 'beforeDamage' },
                     {
                       id: 'camille-firefang-vesperwings-susceptibility',
                       name: 'firefangVesperwings',
@@ -479,7 +479,7 @@ const sheet: OperatorSheet = {
                   stagger: 15,
                   spRecovery: [32, 32, 32, 32, 32, 32, 32, 32, 36, 36, 36, 40],
                   effects: [
-                    { kind: 'infliction', element: 'heat' },
+                    { kind: 'infliction', element: 'heat', applyTiming: 'beforeDamage' },
                     {
                       id: 'camille-hunter-pursuit-ready',
                       name: 'pursuit',

--- a/src/data/operators/estella.ts
+++ b/src/data/operators/estella.ts
@@ -215,7 +215,7 @@ const sheet: OperatorSheet = {
                 {
                   offset: 0.7,
                   stagger: 10,
-                  effects: [{ kind: 'infliction', element: 'cryo' }],
+                  effects: [{ kind: 'infliction', element: 'cryo', applyTiming: 'beforeDamage' }],
                 },
               ],
             },

--- a/src/data/operators/fluorite.ts
+++ b/src/data/operators/fluorite.ts
@@ -235,7 +235,7 @@ const sheet: OperatorSheet = {
               hit: {
                 id: 'fluorite-battle-explosive-expire-damage-hit',
                 stagger: 10,
-                effects: [{ kind: 'infliction', element: 'nature' }],
+                effects: [{ kind: 'infliction', element: 'nature', applyTiming: 'beforeDamage' }],
               },
             },
           ],
@@ -258,7 +258,7 @@ const sheet: OperatorSheet = {
               hit: {
                 id: 'fluorite-battle-explosive-consumed-damage-hit',
                 stagger: 10,
-                effects: [{ kind: 'infliction', element: 'nature' }],
+                effects: [{ kind: 'infliction', element: 'nature', applyTiming: 'beforeDamage' }],
               },
             },
           ],
@@ -305,6 +305,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'cryo',
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'operatorStatus',
                         status: 'fluorite-combo-tracker-cryo',
@@ -314,6 +315,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'nature',
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'operatorStatus',
                         status: 'fluorite-combo-tracker-nature',
@@ -425,6 +427,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'cryo',
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'enemyStatus',
                         status: 'cryoInfliction',
@@ -434,6 +437,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'nature',
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'enemyStatus',
                         status: 'natureInfliction',

--- a/src/data/operators/gilberta.ts
+++ b/src/data/operators/gilberta.ts
@@ -215,7 +215,7 @@ const sheet: OperatorSheet = {
                 {
                   offset: 3.6,
                   stagger: 10,
-                  effects: [{ kind: 'infliction', element: 'nature' }],
+                  effects: [{ kind: 'infliction', element: 'nature', applyTiming: 'beforeDamage' }],
                 },
               ],
             },
@@ -277,7 +277,7 @@ const sheet: OperatorSheet = {
                   offset: 2,
                   stagger: 20,
                   effects: [
-                    { kind: 'infliction', element: 'nature' },
+                    { kind: 'infliction', element: 'nature', applyTiming: 'beforeDamage' },
                     {
                       id: 'gilberta-ultimate-susceptibility',
                       kind: 'status',

--- a/src/data/operators/laevatain.ts
+++ b/src/data/operators/laevatain.ts
@@ -571,7 +571,7 @@ const sheet: OperatorSheet = {
                   hits: [
                     {
                       offset: 0.3,
-                      effects: [{ kind: 'infliction', element: 'heat' }],
+                      effects: [{ kind: 'infliction', element: 'heat', applyTiming: 'beforeDamage' }],
                     },
                   ],
                 },

--- a/src/data/operators/last-rite.ts
+++ b/src/data/operators/last-rite.ts
@@ -283,6 +283,7 @@ const sheet: OperatorSheet = {
                   {
                     kind: 'infliction',
                     element: 'cryo',
+                    applyTiming: 'beforeDamage',
                   },
                 ],
               },

--- a/src/data/operators/perlica.ts
+++ b/src/data/operators/perlica.ts
@@ -187,7 +187,7 @@ const sheet: OperatorSheet = {
                 {
                   offset: 0.43,
                   stagger: 10,
-                  effects: [{ kind: 'infliction', element: 'electric' }],
+                  effects: [{ kind: 'infliction', element: 'electric', applyTiming: 'beforeDamage' }],
                 },
               ],
             },

--- a/src/data/operators/rossi.ts
+++ b/src/data/operators/rossi.ts
@@ -652,6 +652,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'heat',
+                      applyTiming: 'beforeDamage',
                     },
                   ],
                 },

--- a/src/data/operators/snowshine.ts
+++ b/src/data/operators/snowshine.ts
@@ -163,7 +163,7 @@ const sheet: OperatorSheet = {
                   offset: 1.2,
                   spReturn: 30,
                   stagger: 20,
-                  effects: [{ kind: 'infliction', element: 'cryo' }],
+                  effects: [{ kind: 'infliction', element: 'cryo', applyTiming: 'beforeDamage' }],
                 },
               ],
             },

--- a/src/data/operators/tangtang.ts
+++ b/src/data/operators/tangtang.ts
@@ -58,6 +58,7 @@ const sheet: OperatorSheet = {
             {
               kind: 'infliction',
               element: 'cryo',
+              applyTiming: 'beforeDamage',
             },
             {
               id: 'tangtang-waterspouts-sp-return',
@@ -376,6 +377,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'cryo',
+                      applyTiming: 'beforeDamage',
                     },
                     {
                       id: 'tangtang-waterspouts-sp-return',

--- a/src/data/operators/wulfgard.ts
+++ b/src/data/operators/wulfgard.ts
@@ -230,6 +230,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'infliction',
                       element: 'heat',
+                      applyTiming: 'beforeDamage',
                       condition: {
                         kind: 'not',
                         condition: {
@@ -322,7 +323,7 @@ const sheet: OperatorSheet = {
                     {
                       kind: 'ultEnergyGain',
                       value: 10,
-                    },{ kind: 'infliction', element: 'heat' }],
+                    }, { kind: 'infliction', element: 'heat', applyTiming: 'beforeDamage' }],
                 },
               ],
             },

--- a/src/data/operators/xaihi.ts
+++ b/src/data/operators/xaihi.ts
@@ -287,7 +287,7 @@ const sheet: OperatorSheet = {
                       kind: 'ultEnergyGain',
                       value: 10,
                     },
-                    { kind: 'infliction', element: 'cryo' },
+                    { kind: 'infliction', element: 'cryo', applyTiming: 'beforeDamage' },
                   ],
                 },
               ],

--- a/src/data/operators/yvonne.ts
+++ b/src/data/operators/yvonne.ts
@@ -485,7 +485,7 @@ const sheet: OperatorSheet = {
                     effects: () => ENHANCED_BASIC_ATTACK_EFFECTS,
                   },
                 },
-                // Last hit
+                // Last hit (enhanced Final Strike); if solidified, extra cryo hit then consume freeze
                 {
                   element: 'cryo',
                   multiplier: [133, 147, 160, 173, 186, 200, 213, 226, 240, 256, 276, 300],
@@ -498,6 +498,19 @@ const sheet: OperatorSheet = {
                         {
                           kind: 'consume',
                           operatorStatus: 'yvonne-ultimate-crit-rate',
+                        },
+                        {
+                          id: 'yvonne-ultimate-enhanced-final-additional',
+                          kind: 'damageHit',
+                          element: 'cryo',
+                          multiplier: [
+                            267, 294, 320, 347, 374, 400, 427, 454, 480, 514, 554, 600,
+                          ],
+                          condition: {
+                            kind: 'enemyStatus',
+                            status: 'solidification',
+                            consume: true,
+                          },
                         },
                       ],
                     },

--- a/src/data/operators/zhuang-fangyi.ts
+++ b/src/data/operators/zhuang-fangyi.ts
@@ -300,6 +300,7 @@ const ENHANCED_BATTLE_HIT_GROUPS: HitGroup[] = [...Array(9).keys()].flatMap(i =>
             {
               kind: 'infliction' as const,
               element: 'electric' as const,
+              applyTiming: 'beforeDamage' as const,
             },
             {
               kind: 'ultEnergyGain' as const,

--- a/src/simulation/engine/TriggerRegistry.ts
+++ b/src/simulation/engine/TriggerRegistry.ts
@@ -526,8 +526,12 @@ export class TriggerRegistry {
         this.lastFire.set(key, time);
       }
 
-      // Condition check
-      if (!evaluateEffectCondition(resolved.condition, time, sourceTrackId, ctx, enemySnap))
+      // Condition check. Consume effects that gate on "status still present?" must
+      // see post-mutation live enemy state — pre-consume snaps would keep OR-gated
+      // conditional passives stuck after the last matching status expires.
+      const conditionSnap =
+        resolved.kind === 'consume' ? ctx.state.enemy.statusSnapshot() : enemySnap;
+      if (!evaluateEffectCondition(resolved.condition, time, sourceTrackId, ctx, conditionSnap))
         continue;
 
       // Schedule consumption if the condition (or any element of a compound condition) has consume.

--- a/src/simulation/simulator.test.ts
+++ b/src/simulation/simulator.test.ts
@@ -3839,4 +3839,192 @@ describe('independent enemy status instance ids', () => {
     const stacked = damageFor(result, 'probe_inst');
     expect(stacked / baseline).toBeCloseTo(1.2, 2);
   });
+
+  it('arms enemyStatus conditional passives from ally apply and keeps OR buff through solidification', () => {
+    const freezingPointTriggers = [
+      {
+        sourceTrackId: 'yvonne',
+        triggerEffect: {
+          trigger: {
+            kind: 'onStatusApplied' as const,
+            status: ['cryoInfliction', 'solidification'],
+            target: 'enemy' as const,
+            triggerScope: 'global' as const,
+          },
+          effects: [
+            {
+              id: 'yvonne-p2-cryo',
+              kind: 'status' as const,
+              stat: { modifier: 'critDmg' as const },
+              target: 'owner' as const,
+              value: 50,
+              duration: 999,
+              condition: {
+                kind: 'not' as const,
+                condition: { kind: 'operatorStatus' as const, status: 'yvonne-p2-cryo' },
+              },
+            },
+          ],
+        },
+      },
+      {
+        sourceTrackId: 'yvonne',
+        triggerEffect: {
+          trigger: {
+            kind: 'onStatusConsumed' as const,
+            status: ['cryoInfliction', 'solidification'],
+            target: 'enemy' as const,
+            triggerScope: 'global' as const,
+          },
+          effects: [
+            {
+              kind: 'consume' as const,
+              operatorStatus: 'yvonne-p2-cryo',
+              condition: {
+                kind: 'not' as const,
+                condition: {
+                  kind: 'enemyStatus' as const,
+                  status: ['cryoInfliction', 'solidification'],
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        sourceTrackId: 'yvonne',
+        triggerEffect: {
+          trigger: {
+            kind: 'onStatusExpire' as const,
+            status: ['cryoInfliction', 'solidification'],
+            target: 'enemy' as const,
+            triggerScope: 'global' as const,
+          },
+          effects: [
+            {
+              kind: 'consume' as const,
+              operatorStatus: 'yvonne-p2-cryo',
+              condition: {
+                kind: 'not' as const,
+                condition: {
+                  kind: 'enemyStatus' as const,
+                  status: ['cryoInfliction', 'solidification'],
+                },
+              },
+            },
+          ],
+        },
+      },
+    ] satisfies TrackPatch['triggerEffects'];
+
+    const armed = runScenario(
+      [
+        createTrack('yvonne', [
+          createAction('yvonne_ba', 'basicAttack', {
+            startTime: 1,
+            element: 'cryo',
+            hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+          }),
+        ]),
+        createTrack('ally', [
+          createAction('ally_cryo', 'battleSkill', {
+            startTime: 0,
+            hits: [
+              {
+                offset: 0,
+                multiplier: 1,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [{ kind: 'infliction', element: 'cryo', duration: 20 }],
+              },
+            ],
+          }),
+        ]),
+      ],
+      registry(freezingPointTriggers),
+    );
+
+    expect(armed.operatorLog).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'OPERATOR_EFFECT_APPLY',
+          id: 'yvonne-p2-cryo',
+          targetTrackId: 'yvonne',
+          time: 0,
+        }),
+      ]),
+    );
+
+    const baseline = damageFor(
+      runScenario([
+        createTrack('yvonne', [
+          createAction('yvonne_ba', 'basicAttack', {
+            startTime: 1,
+            element: 'cryo',
+            hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+          }),
+        ]),
+      ]),
+      'yvonne_ba_inst',
+    );
+    expect(damageFor(armed, 'yvonne_ba_inst')).toBeGreaterThan(baseline);
+
+    const throughSolidify = runScenario(
+      [
+        createTrack('yvonne', [
+          createAction('force_solidify', 'battleSkill', {
+            startTime: 0.5,
+            hits: [
+              {
+                offset: 0,
+                multiplier: 1,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [
+                  {
+                    kind: 'reaction',
+                    reactionType: 'solidification',
+                    requiresInfliction: ['cryo'],
+                    forced: true,
+                  } as Effect,
+                ],
+              },
+            ],
+          }),
+          createAction('yvonne_ba', 'basicAttack', {
+            startTime: 1,
+            element: 'cryo',
+            hits: [{ offset: 0, multiplier: 100, spRecovery: 0, spReturn: 0, stagger: 0 }],
+          }),
+        ]),
+        createTrack('ally', [
+          createAction('ally_cryo', 'battleSkill', {
+            startTime: 0,
+            hits: [
+              {
+                offset: 0,
+                multiplier: 1,
+                spRecovery: 0,
+                spReturn: 0,
+                stagger: 0,
+                effects: [{ kind: 'infliction', element: 'cryo', duration: 20 }],
+              },
+            ],
+          }),
+        ]),
+      ],
+      registry(freezingPointTriggers),
+    );
+
+    const removed = throughSolidify.operatorLog.some(
+      entry =>
+        entry.type === 'OPERATOR_EFFECT_EXPIRE' &&
+        entry.id === 'yvonne-p2-cryo' &&
+        entry.time <= 1,
+    );
+    expect(removed).toBe(false);
+    expect(damageFor(throughSolidify, 'yvonne_ba_inst')).toBeGreaterThan(baseline);
+  });
 });

--- a/src/stores/timelineStore.ts
+++ b/src/stores/timelineStore.ts
@@ -2685,11 +2685,28 @@ export const useTimelineStore = defineStore('timeline', () => {
         ? { kind: 'not', condition: { kind: 'enemyStatus', status: effect.id } }
         : { kind: 'not', condition: { kind: 'operatorStatus', status: effect.id } };
 
-      const scope = cond.kind === 'operatorStatus' ? 'self' : 'enemy';
+      // Trigger schema uses `target` (not `scope`). Enemy-status passives must be
+      // global so teammate-applied statuses still arm this operator's buff.
+      const target = cond.kind === 'operatorStatus' ? 'self' : 'enemy';
+      const isEnemyStatus = cond.kind === 'enemyStatus';
+      // Global enemy-status triggers set selfTrackId to the applier; remap sheet
+      // `self` → `owner` so the talent buff lands on the passive owner.
+      const armedEffect =
+        isEnemyStatus &&
+        (effect.target === 'self' ||
+          effect.target === undefined ||
+          (typeof effect.target === 'object' && effect.target?.scope === 'self'))
+          ? { ...effect, target: 'owner' as const, duration: 999, condition: idempotencyCondition }
+          : { ...effect, duration: 999, condition: idempotencyCondition };
       out.push({
         triggerEffect: {
-          trigger: { kind: 'onStatusApplied', status: cond.status, scope },
-          effects: [{ ...effect, duration: 999, condition: idempotencyCondition }],
+          trigger: {
+            kind: 'onStatusApplied',
+            status: cond.status,
+            target,
+            ...(isEnemyStatus ? { triggerScope: 'global' } : {}),
+          },
+          effects: [armedEffect],
         },
         sourceSlotIndex: ce.sourceSlotIndex,
         sourceOperatorSlug: ce.sourceOperatorSlug,
@@ -2697,9 +2714,13 @@ export const useTimelineStore = defineStore('timeline', () => {
         stacksConstraint: cond.stacks,
       });
 
-      const removeCondition = cond.stacks
-        ? { kind: 'not', condition: { kind: cond.kind, status: cond.status, stacks: cond.stacks } }
-        : undefined;
+      // Always re-check the full original condition before removing. Without this,
+      // OR conditions (e.g. cryoInfliction | solidification) drop the buff when
+      // only one member is consumed mid-reaction even if the other is still active.
+      const removeCondition = {
+        kind: 'not',
+        condition: { kind: cond.kind, status: cond.status, ...(cond.stacks ? { stacks: cond.stacks } : {}) },
+      };
       const isTeamScoped =
         effect.target === 'team' ||
         (typeof effect.target === 'object' && effect.target?.scope === 'team');
@@ -2707,13 +2728,13 @@ export const useTimelineStore = defineStore('timeline', () => {
         ? {
             kind: 'consume',
             enemyStatus: effect.id,
-            ...(removeCondition ? { condition: removeCondition } : {}),
+            condition: removeCondition,
           }
         : {
             kind: 'consume',
             operatorStatus: effect.id,
             ...(isTeamScoped ? { consumeScope: 'team' } : {}),
-            ...(removeCondition ? { condition: removeCondition } : {}),
+            condition: removeCondition,
           };
 
       ['onStatusExpire', 'onStatusConsumed'].forEach(kind => {
@@ -2722,8 +2743,8 @@ export const useTimelineStore = defineStore('timeline', () => {
             trigger: {
               kind,
               status: cond.status,
-              scope,
-              ...(isTeamScoped ? { triggerScope: 'global' } : {}),
+              target,
+              ...(isEnemyStatus || isTeamScoped ? { triggerScope: 'global' } : {}),
             },
             effects: [removeEffect],
           },


### PR DESCRIPTION
让附着在伤害前生效以便 onStatusApplied 增伤同 hit 吃到；补上伊冯强化终击冻结额外伤害；修复条件被动全局触发与 OR 移除逻辑。